### PR TITLE
add aicoe-aiops-devops group and perms

### DIFF
--- a/docs/argocd_permissions.md
+++ b/docs/argocd_permissions.md
@@ -1,11 +1,13 @@
 ## ArgoCD Permissions 
-Currently there are 2 OpenShift groups (same as ldap) with access: 
+Currently there are 3 OpenShift groups (same as ldap) with access: 
 - `data-hub-openshift-admins` 
 - `aicoe-thoth-devops`
+- `aicoe-aiops-devops`
 
-There are 2 ArgoCD roles with defined policies: 
+There are 3 ArgoCD roles with defined policies: 
 - `thoth-admin `
 - `data-hub-admin`
+- `aiops-admin`
 
 OpenShift groups have the following ArgoCD role associations:
 
@@ -13,6 +15,7 @@ OpenShift groups have the following ArgoCD role associations:
 |:--------------------------- |:---------------- |
 | `aicoe-thoth-devops`        | `thoth-admin`    |
 | `data-hub-openshift-admins` | `data-hub-admin` |
+| `aicoe-aiops-devops`        | `aiops-admin`    |
 
 ArgoCD roles have policies that define their access to ArgoCD resources, they are defined in [prod-vars.yaml](https://github.com/AICoE/argocd-customization/blob/master/vars/prod-vars.yaml).
 

--- a/vars/prod-vars.yaml
+++ b/vars/prod-vars.yaml
@@ -218,6 +218,7 @@ argo_cm: |
             groups:
               - data-hub-openshift-admins
               - aicoe-thoth-devops
+              - aicoe-aiops-devops
     kustomize.buildOptions: "--enable_alpha_plugins"
     repositories: |
       - type: git
@@ -582,3 +583,13 @@ argo_rbac_cm: |
       p, role:data-hub-admin, applications, action/*, data-hub/*, allow
       g, data-hub-openshift-admins, role:argocd-admin
       g, data-hub-openshift-admins, role:data-hub-admin
+
+      p, role:aiops-admin, applications, get, aiops/*, allow
+      p, role:aiops-admin, applications, create, aiops/*, allow
+      p, role:aiops-admin, applications, update, aiops/*, allow
+      p, role:aiops-admin, applications, delete, aiops/*, allow
+      p, role:aiops-admin, applications, sync, aiops/*, allow
+      p, role:aiops-admin, applications, override, aiops/*, allow
+      p, role:aiops-admin, applications, action/*, aiops/*, allow
+      g, aicoe-aiops-devops, role:argocd-admin
+      g, aicoe-aiops-devops, role:aiops-admin


### PR DESCRIPTION
## Related Issues and Dependencies

none

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Adding the rover group `aicoe-aiops-devops` to perform actions on aiops projects

## Description

I just copied what was there for `aicoe-thoth-devops`. Not sure if there's anything more to do