### PR TITLE
Add applications declaritively

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,9 @@
 # AICOE - SRE Docs
 
-Here you will find a compilation of documentation that help achieve efficiency, transparency, and uniformity of performance.
+Here you will find a series of docs that outline various procedures and how-tos
+when interacting with ArgoCD.
+
+Access the ArgoCD UI [here](https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications).
 
 ## Index
 

--- a/docs/application_management.md
+++ b/docs/application_management.md
@@ -1,27 +1,94 @@
 # Application Management
 
-Currently application creation/managment happens via the ArgoCD UI. In the future
-we will create and manage applications declaratively.
+While ArgoCD allows you to create ArgoCD applications via the UI and CLI, it is our
+policy that all applications be created [declaratively](https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#applications).
 
-## Deploying Applications with ArgoCD
+This allows us to easily restore your applications should the need arise. 
 
-1. Log into ArgoCD ui at ```echo https://$(oc get routes | grep argocd-server | awk 'NR==1{print $2}')```
-2. Click create application
-3. Fill the fields out like so:
+## Steps for creating an application
+For your application to show up to ArgoCD you need to do 2 things: 
+1. Create the Application yaml in the appropriate path in a fork 
+2. Submit a PR to this repository 
 
-```text
-Application name: <application_name>
-Project: <your_team_project>
-Sync Policy: Automatic (or manual)
-Sync Option: Check Use A Schema...
-Repository URL: <git_url>
-Revision: <branch_name> or HEAD
-Path: <path_to_overlay> or .
-Cluster: Your cluster address
-Namespace: <application_namespace>
+These steps are outlined in detail below: 
+
+### Step 1. Create the Application Yaml 
+
+Clone the repo and `cd` into where applications are stored:
+ 
+```bash 
+
+$ git clone https://github.com/${GIT_USERNAME}/aicoe-cd.git
+$ cd aicoe-cd/objects/applications
 ```
 
-Leave the rest blank and click create at the top left.
-If everything works the creation slider will go away, refresh the page and the app should be there if isn't already. Click sync and your application should be deployed.
+If your team folder does not exist, create it: 
+
+```bash
+$ mkdir example_team && cd example_team
+```
+
+Let's create a sample application called `example-app`.
+
+
+```yaml
+# aicoe-cd/objects/applications/example_team/example_app.yaml 
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: example_app
+spec:
+  destination:
+    namespace: example_namespace
+    server: http://example_server
+  project: example_project
+  source:
+    path: path/to/kustomization
+    repoURL: http://path-to-example-repo
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+``` 
+This is a basic minimal example application. For additional fields see [here](https://argoproj.github.io/argo-cd/operator-manual/application.yaml).
+
+Let's go over what some of the fields in the `example_app.yaml` refer to: 
+
+- `metadata.name`: the name of the `Application` resource as well as the name as it appears on the ui.
+
+- `spec.project`: the ArgoCD `Project` to which this `Application` belongs, ensure that this `Project` exists in `objects/projects/projects.yaml` .
+
+- `spec.destination.namespace`: the target namespace for this `Application`'s deployment, ensure that this namespace exists in [prod-vars.yaml](https://github.com/AICoE/aicoe-cd/blob/master/vars/prod-vars.yaml) for the appropriate cluster/server.
+
+- `spec.destination.cluster`: the target cluster server name for this `Application`'s deployment, ensure this server exists under `data.server` in [prod-vars.yaml](https://github.com/AICoE/aicoe-cd/blob/master/vars/prod-vars.yaml).
+
+- `spec.source.path`: path to the Kustomization.yaml file relative to the repo's root.
+
+- `spec.source.repoURL`: the repository holding the `Application`'s desired state, ensure this repo exists within `argo_cm` in [prod-vars.yaml](https://github.com/AICoE/aicoe-cd/blob/master/vars/prod-vars.yaml) under data.repositories.
 
 NOTE: You may need to disable schema validation if your deployments are failing. This is due to the ArgoCD api validator having a very strict api spec.
+
+
+### Step 2. Make a Pull request
+
+Commit your changes and submit a pr to `aicoe-sre` repository. An AICOE-SRE team
+member will review your PR. If everything looks good they will merge it and run
+the ArgoCD deployment playbook to bring the changes live. 
+
+
+#### If your application exists in ArgoCD but not on VCS
+We make no guarantees about your application if it does not exist on vcs. Our 
+policy is "_if it's not on vcs, it does not exist_". Luckily, getting the manifests
+for all your applications is easy to do with the argocd cli. 
+
+```bash
+# Login via cli using sso
+$ argocd --insecure --grpc-web login ${ARGOCD_ROUTE}:443 --sso
+
+# Get the application resource details 
+$ argocd app get ${APP_NAME} -o yaml
+``` 

--- a/objects/applications/data_hub/dh-prod-jupyterhub.yaml
+++ b/objects/applications/data_hub/dh-prod-jupyterhub.yaml
@@ -1,0 +1,16 @@
+#apiVersion: argoproj.io/v1alpha1
+#kind: Application
+#metadata:
+#  name: dh-prod-jupyterhub
+#spec:
+#  destination:
+#    namespace: dh-prod-jupyterhub
+#    server: https://datahub.psi.redhat.com:443
+#  project: data-hub
+#  source:
+#    path: applications/jupyterhub/overlays/prod
+#    repoURL: https://github.com/AICoE/aicoe-sre.git
+#    targetRevision: HEAD
+#  syncPolicy:
+#    syncOptions:
+#    - Validate=false

--- a/objects/applications/data_hub/dh-psi-monitoring.yaml
+++ b/objects/applications/data_hub/dh-psi-monitoring.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dh-psi-monitoring
+spec:
+  destination:
+    namespace: dh-psi-monitoring
+    server: https://api.ocp.prod.psi.redhat.com:6443
+  project: data-hub
+  source:
+    path: monitoring/psi-prod-cluster/overlays/prod
+    repoURL: https://github.com/AICoE/aicoe-sre.git
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+    - Validate=false

--- a/objects/applications/data_hub/dh-stage-jupyterhub.yaml
+++ b/objects/applications/data_hub/dh-stage-jupyterhub.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dh-stage-jupyterhub
+spec:
+  destination:
+    namespace: dh-stage-jupyterhub
+    server: https://paas.stage.psi.redhat.com:443
+  project: data-hub
+  source:
+    path: applications/jupyterhub/overlays/stage
+    repoURL: https://github.com/AICoE/aicoe-sre.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -135,3 +135,59 @@
         merge_type:
           - merge
       with_filetree: objects/patches/
+
+    - name: Get Application Controller Service Account
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: ServiceAccount
+        name: argocd-application-controller
+        namespace: "{{ namespace }}"
+        verify_ssl: "no"
+      register: appctrl_sa
+
+    - name: Get Application Controller Service Account Secrets
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Secret
+        name: "{{ item.name }}"
+        namespace: "{{ namespace }}"
+        verify_ssl: "no"
+      register: appctrl_sa_secrets
+      when: "'token' in item.name"
+      with_items: "{{ appctrl_sa.resources[0].secrets }}"
+
+    - set_fact:
+        appctrl_sa_token: "{{ item.resources[0].data.token | b64decode }}"
+      when: "'resources' in item"
+      with_items: "{{ appctrl_sa_secrets.results }}"
+      no_log: "True"
+
+    - name: Deploy ArgoCD Projects
+      k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: present
+        namespace: "{{ namespace }}"
+        verify_ssl: "no"
+        api_key: "{{ appctrl_sa_token }}"
+        definition: "{{ lookup('template', 'objects/projects/'+item.path ) }}"
+      with_filetree: objects/projects/
+      when: target_env == 'prod'
+
+    - name: Get all applications
+      find:
+        paths: objects/applications/
+        recurse: yes
+      register: argocd_apps
+
+    - name: Deploy ArgoCD Applications
+      k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: present
+        namespace: "{{ namespace }}"
+        verify_ssl: "no"
+        definition: "{{ lookup('template', file.path ) }}"
+        api_key: "{{ appctrl_sa_token }}"
+      with_items: "{{ argocd_apps.files }}"
+      loop_control:
+        loop_var: file
+      when: target_env == 'prod'


### PR DESCRIPTION
## This introduces a breaking change

- [x] Yes
- [ ] No

## Description

This PR introduces steps and the procedure for storing ArgoCD applications on vcs. I've included the datahub applications (with prod commented out for now) as examples. We should move to store all applications declaratively in a similar manner. You can view your applications yamls from argocd cli or using the argocd application-controller sa by running the following: 
```
$ oc project aicoe-argocd 
$ oc login --token=$(oc sa get-token argocd-application-controller)
$ oc get Applications -n aicoe-argocd 
```

