### PR TITLE
Add dh-stage-argo namespace with Argo and Argo events apps

### DIFF
--- a/objects/applications/data_hub/dh-stage-argo.yaml
+++ b/objects/applications/data_hub/dh-stage-argo.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo
+spec:
+  destination:
+    namespace: dh-stage-argo
+    server: https://paas.stage.psi.redhat.com:443
+  project: data-hub
+  source:
+    path: applications/argo/overlays/dh-stage-argo
+    repoURL: https://github.com/AICoE/aicoe-sre.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-events
+spec:
+  destination:
+    namespace: dh-stage-argo
+    server: https://paas.stage.psi.redhat.com:443
+  project: data-hub
+  source:
+    path: applications/argo-events/overlays/dh-stage-argo
+    repoURL: https://github.com/AICoE/aicoe-sre.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/vars/prod-vars.yaml
+++ b/vars/prod-vars.yaml
@@ -70,6 +70,7 @@ clusters:
       name: paas.stage.psi.redhat.com
       namespaces:
         - dh-stage-jupyterhub
+        - dh-stage-argo
       server: https://paas.stage.psi.redhat.com:443
       config:
         bearerToken: !vault |
@@ -238,6 +239,15 @@ argo_cm: |
         - "TaskRun"
         clusters:
         - "*"
+      - apiGroups:
+        - "*"
+        kinds:
+        - CustomResourceDefinition
+        - ClusterRole
+        clusters:
+        - https://api.ocp.prod.psi.redhat.com:6443
+        - https://datahub.psi.redhat.com:443
+        - https://paas.stage.psi.redhat.com:443
     resource.inclusions: |
       - apiGroups:
         - '*'
@@ -297,6 +307,19 @@ argo_cm: |
         - WorkflowTemplate
         clusters:
         - https://api.ocp.prod.psi.redhat.com:6443
+      - apiGroups:
+        - argoproj.io
+        kinds:
+        - ClusterWorkflowTemplate
+        - CronWorkflow
+        - Workflow
+        - WorkflowTemplate
+        - EventBus
+        - EventSource
+        - Gateway
+        - Sensor
+        clusters:
+        - https://paas.stage.psi.redhat.com:443
       - apiGroups:
         - authorization.openshift.io
         kinds:


### PR DESCRIPTION
## Related Issues and Dependencies

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Make Argo CD deploy Argo and Argo Events into `dh-stage-argo` namespace on DataHub Stage cluster. 

## Description

Let's start rolling out the new Argo into DH namespaces. This PR kicks off the process via deploying Argo and Argo Events into the staging environment.

Is it possible to list multiple `Application` resources in a single file? I hope so. It may be required to prune the namespace before deploying this PR via Argo CD. The `dh-stage-argo` namespace should not be a heavily used Argo namespace.
