### PR TITLE
Add custom tools - Kustomize v3.6.1

### DIFF
--- a/objects/applications/data_hub/dh-stage-argo.yaml
+++ b/objects/applications/data_hub/dh-stage-argo.yaml
@@ -11,6 +11,8 @@ spec:
     path: applications/argo/overlays/dh-stage-argo
     repoURL: https://github.com/AICoE/aicoe-sre.git
     targetRevision: HEAD
+    kustomize:
+      version: v3.6.1
   syncPolicy:
     automated:
       prune: true
@@ -31,6 +33,8 @@ spec:
     path: applications/argo-events/overlays/dh-stage-argo
     repoURL: https://github.com/AICoE/aicoe-sre.git
     targetRevision: HEAD
+    kustomize:
+      version: v3.6.1
   syncPolicy:
     automated:
       prune: true

--- a/objects/namespace-install.yaml
+++ b/objects/namespace-install.yaml
@@ -2360,6 +2360,19 @@ spec:
         app.kubernetes.io/name: argocd-repo-server
     spec:
       automountServiceAccountToken: false
+      volumes:
+        - name: custom-tools
+          emptyDir: {}
+      initContainers:
+        - name: download-tools
+          image: alpine:latest
+          command: [sh, -c]
+          args:
+            - wget -qO- https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.6.1/kustomize_v3.6.1_linux_amd64.tar.gz | tar -xvzf - &&
+              mv kustomize /custom-tools/kustomize_3_6_1
+          volumeMounts:
+            - mountPath: /custom-tools
+              name: custom-tools
       containers:
       - command:
         - uid_entrypoint.sh
@@ -2393,6 +2406,8 @@ spec:
           name: tls-certs
         - name: key
           mountPath: /key
+        - name: custom-tools
+          mountPath: /custom-tools
         env:
           - name: GNUPGHOME
             value: /home/argocd/.gnupg

--- a/vars/prod-vars.yaml
+++ b/vars/prod-vars.yaml
@@ -220,6 +220,7 @@ argo_cm: |
               - aicoe-thoth-devops
               - aicoe-aiops-devops
     kustomize.buildOptions: "--enable_alpha_plugins"
+    kustomize.version.v3.6.1: /custom-tools/kustomize_3_6_1
     repositories: |
       - type: git
         url: https://github.com/goern/strimzi-application.git


### PR DESCRIPTION
## Related Issues

n/a

## This introduces a breaking change

- [x] Yes
- [ ] No

## This Pull Request implements

Argo uses remote kustomization base. Kustomize included in our ArgoCD doesn't like that. This PR is adding `custom-tools` volume according to https://argoproj.github.io/argo-cd/operator-manual/custom_tools/#adding-tools-via-volume-mounts and https://argoproj.github.io/argo-cd/user-guide/kustomize/#custom-kustomize-versions so `kustomize.version.v3.6.1` can be used.