### PR TITLE
Rename Argo and Argo Events to respect the convention

### DIFF
--- a/objects/applications/data_hub/dh-stage-argo.yaml
+++ b/objects/applications/data_hub/dh-stage-argo.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: argo
+  name: argo.dh-stage-argo
 spec:
   destination:
     namespace: dh-stage-argo
@@ -21,7 +21,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: argo-events
+  name: argo-events.dh-stage-argo
 spec:
   destination:
     namespace: dh-stage-argo


### PR DESCRIPTION
## Related Issues

n/a

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

The Argo and Argo Events app is expected to be deployed to a single namespace. Use the namespace name as convention. Hopefully Argo CD respects Kubernetes name convention and allow for `.` in names

Reference:
- https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/identifiers.md#definitions
- https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names