### PR TITLE
include aicoe-ci configuration file

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,0 +1,9 @@
+check:
+  - thoth-precommit
+  - thoth-build
+build:
+  build-stratergy: Dockerfile
+  registry: quay.io
+  registry-org: aicoe
+  registry-project: argocd
+  registry-secret: aicoe-pusher-secret


### PR DESCRIPTION
include aicoe-ci configuration file
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues

Build image for aicoe-cd on tag.

## This introduces a breaking change

- [x] No

## This Pull Request implements

aicoe-ci would use this config file for getting information on where to push the build image.

## Description

aicoe-ci configuration file.

## Checklist for migrating an Application to ArgoCD

Not related.