### PR TITLE
thoth-station application manifest that is to be handled by argo

### DIFF
--- a/objects/applications/thoth-station/stage/stage-thoth-chat-notification.yaml
+++ b/objects/applications/thoth-station/stage/stage-thoth-chat-notification.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stage-thoth-chat-notification
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: chat-notification/overlays/stage
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-infra-stage
+  syncPolicy:
+    automated:
+      selfHeal: true

--- a/objects/applications/thoth-station/test/test-amun.yaml
+++ b/objects/applications/thoth-station/test/test-amun.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-amun
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: amun/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-advise-reporter.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-advise-reporter.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-advise-reporter
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: advise-reporter/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-adviser.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-adviser.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-adviser
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: adviser/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-cve-update.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-cve-update.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-cve-update
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: cve-update/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-graph-sync.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-graph-sync.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-graph-sync
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: graph-sync/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-investigator.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-investigator.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-investigator
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: investigator/overlays/test
+    targetRevision: HEAD
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-kebechet.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-kebechet.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-kebechet
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: kebechet/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-management-api.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-management-api.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-management-api
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: management-api/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-metrics-exporter.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-metrics-exporter.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-metrics-exporter
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: metrics-exporter/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-mi-scheduler.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-mi-scheduler.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-mi-scheduler
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: mi-scheduler/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-package-extract.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-package-extract.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-package-extract
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: package-extract/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-package-update.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-package-update.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-package-update
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: package-update/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-security-indicators.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-security-indicators.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-security-indicators
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: security-indicators/overlays/test
+    targetRevision: HEAD
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-slo-reporter.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-slo-reporter.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-slo-reporter
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: slo-reporter/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-solver.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-solver.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-solver
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: solver/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}

--- a/objects/applications/thoth-station/test/test-thoth-user-api.yaml
+++ b/objects/applications/thoth-station/test/test-thoth-user-api.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-user-api
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: user-api/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}


### PR DESCRIPTION
## Related Issues

Related-To: https://github.com/thoth-station/thoth-application/issues/175

## This introduces a breaking change

- [x] No

## This Pull Request implements

Including the thoth-station test application manifest files that would be used to deploy the application by argocd.
## Description

thoth-station application manifest that is to be handled by argo
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Checklist for migrating an Application to ArgoCD

When migrating an application's deployment to be managed by ArgoCD use the following checklist to verify your process.

Items to complete before making a migration PR
- [x] Ensure your application manifests can be built using Kustomize.
- [x] If using secrets, make sure to include the .sops.yaml file in your repository.
- [x] Make sure to create the role granting access to namespace. See [here](cluster_ns_management.md#deploying-to-a-namespace) for more info. This role is tracked in your application manifests.

Items to include within the migration PR
- [x] Ensure your namespace exists in the cluster spec in the [prod-vars.yaml](../vars/prod-vars.yaml) file (for the appropriate cluster).
- [x] Ensure the application repository is added in the `argo_cm` file in [prod-vars.yaml](../vars/prod-vars.yaml).
- [x] Ensure that all OCP resources that will be managed by ArgoCD on this cluster are included in the `inclusions` list in [prod-vars.yaml](../vars/prod-vars.yaml). See [here](cluster_ns_management.md#cluster-inclusions) for more info.
- [x] Create the ArgoCD Application, see [here](application_management.md) for instructions.
