### PR TITLE
include aicoe, aicoe-prod-bots namespaces to thoth-station namespaces

### DIFF
--- a/vars/prod-vars.yaml
+++ b/vars/prod-vars.yaml
@@ -135,6 +135,8 @@ clusters:
         - fpokorny-thoth-dev
         - goern-thoth-dev
         - kpostlet-thoth-dev
+        - aicoe
+        - aicoe-prod-bots
         - thoth-amun-api-stage
         - thoth-amun-inspection-stage
         - thoth-backend-stage


### PR DESCRIPTION
include aicoe, aicoe-prod-bots namespaces to thoth-station namespaces
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues

None, but we would like to deploy some applications in those namespaces.

## This introduces a breaking change

- [x] No

## This Pull Request implements

included two new namespaces to thoth-station list of namespaces.

## Description

we would like to manage the application deployed in these namespaces to be managed by argocd as well.

## Checklist for migrating an Application to ArgoCD

When migrating an application's deployment to be managed by ArgoCD use the following checklist to verify your process.

Items to complete before making a migration PR
- [x] Make sure to create the role granting access to the namespace. See [here](cluster_ns_management.md#deploying-to-a-namespace) for more info. This role is tracked in your application manifests.

Items to include within the migration PR
- [x] Ensure your namespace exists in the cluster spec in the [prod-vars.yaml](../vars/prod-vars.yaml) file (for the appropriate cluster).
- [x] If you are switching between ArgoCD managed namespaces, and that namespace was deleted in OCP, then ensure it is also removed from [prod-vars.yaml](../vars/prod-vars.yaml).