### PR TITLE
Add aiops-prod-argo

### DIFF
--- a/objects/applications/aiops/aiops-prod-argo.yaml
+++ b/objects/applications/aiops/aiops-prod-argo.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo.aiops-prod-argo
+spec:
+  destination:
+    namespace: aiops-prod-argo
+    server: https://api.ocp.prod.psi.redhat.com:6443
+  project: aiops
+  source:
+    path: applications/argo/overlays/aiops-prod-argo
+    repoURL: https://github.com/AICoE/aicoe-sre.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-events.aiops-prod-argo
+spec:
+  destination:
+    namespace: aiops-prod-argo
+    server: https://api.ocp.prod.psi.redhat.com:6443
+  project: aiops
+  source:
+    path: applications/argo-events/overlays/aiops-prod-argo
+    repoURL: https://github.com/AICoE/aicoe-sre.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/vars/prod-vars.yaml
+++ b/vars/prod-vars.yaml
@@ -144,6 +144,7 @@ clusters:
         - thoth-infra-stage
         - thoth-middletier-stage
         - thoth-test-core
+        - aiops-prod-argo
       server: https://api.ocp.prod.psi.redhat.com:6443
       config:
         bearerToken: !vault |


### PR DESCRIPTION
## Related Issues

Requires: https://github.com/AICoE/aicoe-sre/pull/40

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Add `aiops-prod-argo` namespace on `ocp.prod.psi.redhat.com`

## Checklist for migrating an Application to ArgoCD

When migrating an application's deployment to be managed by ArgoCD use the following checklist to verify your process.

Items to complete before making a migration PR
- [x] Ensure your application manifests can be built using Kustomize.
- [x] If using secrets, make sure to include the .sops.yaml file in your repository.
- [x] Make sure to create the role granting access to namespace. See [here](cluster_ns_management.md#deploying-to-a-namespace) for more info. This role is tracked in your application manifests.

Items to include within the migration PR
- [x] Ensure your namespace exists in the cluster spec in the [prod-vars.yaml](../vars/prod-vars.yaml) file (for the appropriate cluster).
- [x] If you are switching between ArgoCD managed namespaces, and that namespace was deleted in OCP, then ensure it is also removed from [prod-vars.yaml](../vars/prod-vars.yaml).
- [x] Ensure the application repository is added in the `argo_cm` file in [prod-vars.yaml](../vars/prod-vars.yaml).
- [x] Ensure that all OCP resources that will be managed by ArgoCD on this cluster are included in the `inclusions` list in [prod-vars.yaml](../vars/prod-vars.yaml). See [here](cluster_ns_management.md#cluster-inclusions) for more info.
- [x] Create the ArgoCD Application, see [here](application_management.md) for instructions.
