### PR TITLE
Fix listing of AI-Ops applications in kustomization.yaml file

### DIFF
--- a/manifests/overlays/prod/applications/aiops/kustomization.yaml
+++ b/manifests/overlays/prod/applications/aiops/kustomization.yaml
@@ -1,2 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+resources:
+  - argo-analytics.yaml
+  - aiops-prod-argo.yaml


### PR DESCRIPTION
## Related Issues

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

AI-Ops project was missing its applications from the `kustomization.yaml` file.