### PR TITLE
Use correct sesheta token

### DIFF
--- a/manifests/overlays/dev/secrets/auth/srcops.enc.yaml
+++ b/manifests/overlays/dev/secrets/auth/srcops.enc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-    token: ENC[AES256_GCM,data:ZdNqwudWlu5Uo9qiM3cwg1pH1yxV6QarsGkTTcJwGf6kd8XWEvZcusyrFsyyJdr8GGBo8VeOSqc=,iv:oEZ/G03BLY6JJuYho2oXSDMOn2rBnmsNbMMOzKTxJYc=,tag:2TgFIaIZeIYvbCkQ8e4TmA==,type:str]
-    username: ENC[AES256_GCM,data:pqnX9CZY71VOUVJV,iv:c0Bc4zbaoEJXmUSkNqxOY9ZzdObJdeEyLarfztPD6l8=,tag:1mVQe3tSyAAx5z9wd6TXqg==,type:str]
+    token: ENC[AES256_GCM,data:zGpAR21DLvC+ccPJsQnbzINijApWNUYLv+G5vKxnvPsiLH7zLcX5NPA7t2ouYRHWJE6wMqgeBN4=,iv:+j/VhYpC7NiuKjsdfqwP+6gu0g2tgY+HX6QHFQHqoPo=,tag:wGdDTLK6HbCR/Xy0f0TanA==,type:str]
+    username: ENC[AES256_GCM,data:mXWaip8JjOfdrVhd,iv:idQkXqhl1C0sCXGtBFk4eKLHShEWS6iguWagwtuN9CI=,tag:sALYN73+B9wrtNrbYMSUsQ==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -11,22 +11,22 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-08-17T11:54:32Z'
-    mac: ENC[AES256_GCM,data:N8+GvgEjBgPkkRT00ad2xWOhJ3GB/Qgfh4G2fHtrlJa/2NEac+VzZelbaYbjUoEkl+Cr6z9+Wmd8DmkScIT1FoQbTQv8Pmgq+sGtTjBu3aPIdKeAtGdQWrvZVcZFDjBYbMJqOfQjL88QkNTv+2Sn7hbSLbrZlDVd7iQGpCvuVd4=,iv:FSXPibDrdjRBQpnuRCHNse+7LNgTmvtkUHon6WuqSgY=,tag:ZyK5Lvi4IQVcLzhaTXPnVQ==,type:str]
+    lastmodified: '2020-08-19T12:22:38Z'
+    mac: ENC[AES256_GCM,data:fSZ3eDejoF044zeBrXgQTItD4OIPgyakjhR/qtSOb+6woKlD/jPFOPiy/2hkk7eZTnCB/Rvy11RpXV0CeT+nMzjgswO7YIJcKYc5FJ5vPbtXhyIpDcKtV4QzAs1MaggndqMiA6ZICV7mim6cUjt2aVsc7Mf2LojSw2sj9iuCGng=,iv:HPkzsnrWw5XpaM+Qpz4mJEcRJBSuuc/vT08aBomaSRQ=,tag:a8Wq/rHwY6AjJsyYlnY59A==,type:str]
     pgp:
-    -   created_at: '2020-08-17T11:54:28Z'
+    -   created_at: '2020-08-19T12:22:38Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf/Yd0gknMKUJ1V3hj02LMx+f55pkvRFn4lj9/lP61uFOX2
-            jKH9o+zKK5mDQI2lQW3l5fn9bBa85z8C9qlm6kJB2BUb55gV7iR5wamNjU02r6N8
-            YBhCOoVZN47pD03hBfAJQ41wKte7/jjVoKAavEQFb2J3QeQIfvbe6qiP+fE8dudb
-            H+FNu7J2Gw+6S0TNGK9dRe87zhzO/Qvso4egQl5RJxqQMAsD+4+lU1pV/ge0I9iP
-            VOVQOCuKQe1k8Set4hQ1BoxWWLBQ7TnFoZCqVUlZf6WpmR2bqWD4B7B8AiJcV/fQ
-            LTKasdy7cfcWIcjbK+QCfogLmgLBNpQ8Iz6WFrZBKNJcAcPS5SePJQZEzyw300t4
-            e5eej1OQptCkzKkTgSS9IRAmnJYF/xm7VNA6+FP5IzghUmyKRu1Gnt087VNfGT1k
-            0vvATPuV38iAW+NCXZ9fl6uD0IHRA8qyNfCXF/A=
-            =u4BY
+            hQEMA/irrHa183bxAQf6AoHmkInC5+UyoL3iID2KNaWeMbcVW/cVlQ4v9XWK7TCx
+            ALVkLiIKAkLqlhigvHnL+rXNFEAoXPuqEZqqUFTJv66KVyxy2j2Nq8qi/UaK5/7c
+            O+S9akP6bkENYTRAd8J5nznpVSFz39YHFbIb9y58VhZtVqQ551aYtz+UUDrO46d1
+            lyLsgQoVBrH1I1comxvKLFmYUs0I3Xh0KHsN53q8q3HaC2VY+pXRfofAfc29i6aW
+            AVAKFXc0AtBXmKcynxRJ3gG+UO8QDQyyNTb+wRKrIDDbYDGjL6+8rfuqLzuj9rqh
+            3a+YM4aVXj4Nn1tr+q6D6arIXXaYs9a1air0d+znVtJcAa146uKQdm7HYXmllIjs
+            Hq+TPKiO8y4n6IYnc8m/mNfcQnWja6WYVDAfgzDAhlTgLLm6DAWJ5Bq/nkFAnT74
+            MR9filiRvgbm+5wT9tvbOKnruiFXersISthV3uY=
+            =DHVY
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$

--- a/manifests/overlays/prod/secrets/auth/srcops.enc.yaml
+++ b/manifests/overlays/prod/secrets/auth/srcops.enc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-    token: ENC[AES256_GCM,data:ZdNqwudWlu5Uo9qiM3cwg1pH1yxV6QarsGkTTcJwGf6kd8XWEvZcusyrFsyyJdr8GGBo8VeOSqc=,iv:oEZ/G03BLY6JJuYho2oXSDMOn2rBnmsNbMMOzKTxJYc=,tag:2TgFIaIZeIYvbCkQ8e4TmA==,type:str]
-    username: ENC[AES256_GCM,data:pqnX9CZY71VOUVJV,iv:c0Bc4zbaoEJXmUSkNqxOY9ZzdObJdeEyLarfztPD6l8=,tag:1mVQe3tSyAAx5z9wd6TXqg==,type:str]
+    token: ENC[AES256_GCM,data:zGpAR21DLvC+ccPJsQnbzINijApWNUYLv+G5vKxnvPsiLH7zLcX5NPA7t2ouYRHWJE6wMqgeBN4=,iv:+j/VhYpC7NiuKjsdfqwP+6gu0g2tgY+HX6QHFQHqoPo=,tag:wGdDTLK6HbCR/Xy0f0TanA==,type:str]
+    username: ENC[AES256_GCM,data:mXWaip8JjOfdrVhd,iv:idQkXqhl1C0sCXGtBFk4eKLHShEWS6iguWagwtuN9CI=,tag:sALYN73+B9wrtNrbYMSUsQ==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -11,22 +11,22 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-08-17T11:54:32Z'
-    mac: ENC[AES256_GCM,data:N8+GvgEjBgPkkRT00ad2xWOhJ3GB/Qgfh4G2fHtrlJa/2NEac+VzZelbaYbjUoEkl+Cr6z9+Wmd8DmkScIT1FoQbTQv8Pmgq+sGtTjBu3aPIdKeAtGdQWrvZVcZFDjBYbMJqOfQjL88QkNTv+2Sn7hbSLbrZlDVd7iQGpCvuVd4=,iv:FSXPibDrdjRBQpnuRCHNse+7LNgTmvtkUHon6WuqSgY=,tag:ZyK5Lvi4IQVcLzhaTXPnVQ==,type:str]
+    lastmodified: '2020-08-19T12:22:38Z'
+    mac: ENC[AES256_GCM,data:fSZ3eDejoF044zeBrXgQTItD4OIPgyakjhR/qtSOb+6woKlD/jPFOPiy/2hkk7eZTnCB/Rvy11RpXV0CeT+nMzjgswO7YIJcKYc5FJ5vPbtXhyIpDcKtV4QzAs1MaggndqMiA6ZICV7mim6cUjt2aVsc7Mf2LojSw2sj9iuCGng=,iv:HPkzsnrWw5XpaM+Qpz4mJEcRJBSuuc/vT08aBomaSRQ=,tag:a8Wq/rHwY6AjJsyYlnY59A==,type:str]
     pgp:
-    -   created_at: '2020-08-17T11:54:28Z'
+    -   created_at: '2020-08-19T12:22:38Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf/Yd0gknMKUJ1V3hj02LMx+f55pkvRFn4lj9/lP61uFOX2
-            jKH9o+zKK5mDQI2lQW3l5fn9bBa85z8C9qlm6kJB2BUb55gV7iR5wamNjU02r6N8
-            YBhCOoVZN47pD03hBfAJQ41wKte7/jjVoKAavEQFb2J3QeQIfvbe6qiP+fE8dudb
-            H+FNu7J2Gw+6S0TNGK9dRe87zhzO/Qvso4egQl5RJxqQMAsD+4+lU1pV/ge0I9iP
-            VOVQOCuKQe1k8Set4hQ1BoxWWLBQ7TnFoZCqVUlZf6WpmR2bqWD4B7B8AiJcV/fQ
-            LTKasdy7cfcWIcjbK+QCfogLmgLBNpQ8Iz6WFrZBKNJcAcPS5SePJQZEzyw300t4
-            e5eej1OQptCkzKkTgSS9IRAmnJYF/xm7VNA6+FP5IzghUmyKRu1Gnt087VNfGT1k
-            0vvATPuV38iAW+NCXZ9fl6uD0IHRA8qyNfCXF/A=
-            =u4BY
+            hQEMA/irrHa183bxAQf6AoHmkInC5+UyoL3iID2KNaWeMbcVW/cVlQ4v9XWK7TCx
+            ALVkLiIKAkLqlhigvHnL+rXNFEAoXPuqEZqqUFTJv66KVyxy2j2Nq8qi/UaK5/7c
+            O+S9akP6bkENYTRAd8J5nznpVSFz39YHFbIb9y58VhZtVqQ551aYtz+UUDrO46d1
+            lyLsgQoVBrH1I1comxvKLFmYUs0I3Xh0KHsN53q8q3HaC2VY+pXRfofAfc29i6aW
+            AVAKFXc0AtBXmKcynxRJ3gG+UO8QDQyyNTb+wRKrIDDbYDGjL6+8rfuqLzuj9rqh
+            3a+YM4aVXj4Nn1tr+q6D6arIXXaYs9a1air0d+znVtJcAa146uKQdm7HYXmllIjs
+            Hq+TPKiO8y4n6IYnc8m/mNfcQnWja6WYVDAfgzDAhlTgLLm6DAWJ5Bq/nkFAnT74
+            MR9filiRvgbm+5wT9tvbOKnruiFXersISthV3uY=
+            =DHVY
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$


### PR DESCRIPTION
## Related Issues

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Change sesheta's srcops token from (`gopass AICoE/thoth/sesheta` properties) `SESHETA_GITHUB_SRCOPS_ACCESS_TOKEN` to `Std Access Token`.

@goern Not sure if there's any other use for the  `SESHETA_GITHUB_SRCOPS_ACCESS_TOKEN`, but it doesn't work for github any more. You might want to check, if that token is still needed. :wink: 

```bash
$ SESHETA_GITHUB_SRCOPS_ACCESS_TOKEN=`gopass AICoE/thoth/sesheta | grep -oP "(?<=SESHETA_GITHUB_SRCOPS_ACCESS_TOKEN=).*"`

$ STD_TOKEN=`gopass AICoE/thoth/sesheta | sed -n -e "s/Std Access Token:\W*\(\w*\)/\1/p"`

$ curl -u sesheta:`echo $SESHETA_GITHUB_SRCOPS_ACCESS_TOKEN` https://api.github.com/user
{
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest"
}

$ curl -u sesheta:`echo $STD_TOKEN` https://api.github.com/user
{
  "login": "sesheta",
  "id": 33906690,
  "node_id": "MDQ6VXNlcjMzOTA2Njkw",
...
}
```