### PR TITLE
include more thoth-station argocd application

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/kustomization.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/kustomization.yaml
@@ -20,7 +20,9 @@ resources:
 - stage/stage-thoth-graph-sync-middletier.yaml
 - stage/stage-thoth-kebechet.yaml
 - stage/stage-thoth-management-api.yaml
+- stage/stage-thoth-metrics-exporter.yaml
 - stage/stage-thoth-package-extract.yaml
+- stage/stage-thoth-package-releases.yaml
 - stage/stage-thoth-revsolver.yaml
 - stage/stage-thoth-security-indicators.yaml
 - stage/stage-thoth-solver.yaml
@@ -39,6 +41,7 @@ resources:
 - test/test-thoth-metrics-exporter.yaml
 - test/test-thoth-mi-scheduler.yaml
 - test/test-thoth-package-extract.yaml
+- test/test-thoth-package-releases.yaml
 - test/test-thoth-package-update.yaml
 - test/test-thoth-revsolver.yaml
 - test/test-thoth-security-indicators.yaml

--- a/manifests/overlays/prod/applications/thoth-station/stage/stage-thoth-metrics-exporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/stage/stage-thoth-metrics-exporter.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stage-thoth-metrics-exporter
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: metrics-exporter/overlays/stage
+    targetRevision: HEAD
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-infra-stage
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true

--- a/manifests/overlays/prod/applications/thoth-station/stage/stage-thoth-package-releases.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/stage/stage-thoth-package-releases.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stage-thoth-package-releases
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: package-releases/overlays/stage
+    targetRevision: HEAD
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-frontend-stage
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-package-releases.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-package-releases.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-package-releases
+spec:
+  project: thoth
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: package-releases/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

include metrics-exporter and package-releases job application.

## Description

include more thoth-station argocd application
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Checklist for migrating an Application to ArgoCD

When migrating an application's deployment to be managed by ArgoCD use the following checklist to verify your process.

Items to complete before making a migration PR
- [x] Ensure your application manifests can be built using Kustomize.
- [x] If using secrets, make sure to include the .sops.yaml file in your repository.
- [x] Make sure to create the role granting access to namespace. See [here](cluster_ns_management.md#deploying-to-a-namespace) for more info. This role is tracked in your application manifests.

Items to include within the migration PR
- [x] Ensure your namespace exists in the cluster spec in the [prod-vars.yaml](../vars/prod-vars.yaml) file (for the appropriate cluster).
- [x] If you are switching between ArgoCD managed namespaces, and that namespace was deleted in OCP, then ensure it is also removed from [prod-vars.yaml](../vars/prod-vars.yaml).
- [x] Ensure the application repository is added in the `argo_cm` file in [prod-vars.yaml](../vars/prod-vars.yaml).
- [x] Ensure that all OCP resources that will be managed by ArgoCD on this cluster are included in the `inclusions` list in [prod-vars.yaml](../vars/prod-vars.yaml). See [here](cluster_ns_management.md#cluster-inclusions) for more info.
- [x] Create the ArgoCD Application, see [here](application_management.md) for instructions.
