### PR TITLE
Add helm plugin and configuration to argocd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ ARG ARGO_CD_VERSION="v1.6.1"
 # Always match Argo CD Dockerfile's Go version!
 # https://github.com/argoproj/argo-cd/blob/master/Dockerfile
 ARG KSOPS_VERSION="v2.1.2-go-1.14"
-
 #--------------------------------------------#
 #--------Build KSOPS and Kustomize-----------#
 #--------------------------------------------#
@@ -19,9 +18,12 @@ FROM argoproj/argocd:$ARGO_CD_VERSION
 USER root
 
 # Set the kustomize home directory
-ENV XDG_CONFIG_HOME=$HOME/.config
+ENV XDG_DATA_HOME=/home/argocd/.local/share
+ENV XDG_CACHE_HOME=/home/argocd/.cache
+ENV XDG_CONFIG_HOME=/home/argocd/.config
 ENV KUSTOMIZE_PLUGIN_PATH=$XDG_CONFIG_HOME/kustomize/plugin/
-
+ARG SOPS_VERSION="3.2.0"
+ARG HELM_SECRETS_VERSION="2.0.2"
 ARG PKG_NAME=ksops
 
 # Override the default kustomize executable with the Go built version
@@ -29,6 +31,19 @@ COPY --from=ksops-builder /go/bin/kustomize /usr/local/bin/kustomize
 
 # Copy the plugin to kustomize plugin path
 COPY --from=ksops-builder /go/src/github.com/viaduct-ai/kustomize-sops/*  $KUSTOMIZE_PLUGIN_PATH/viaduct.ai/v1/${PKG_NAME}/
+
+# Install helm secrets and sops
+RUN apt-get update && \
+    apt-get install -y \
+        curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    curl -o /usr/local/bin/sops -L https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux && \
+    chmod +x /usr/local/bin/sops && \
+    mkdir -p $XDG_DATA_HOME/helm/plugins && \
+    helm plugin install https://github.com/zendesk/helm-secrets --version=$HELM_SECRETS_VERSION && \
+    chgrp -R 0 $XDG_DATA_HOME/helm/plugins/helm-secrets/ && \
+    chmod -R g+rwX $XDG_DATA_HOME/helm/plugins/helm-secrets/
 
 # Switch back to non-root user
 USER argocd

--- a/manifests/base/resources/deployments/argocd-repo-server_patch.yaml
+++ b/manifests/base/resources/deployments/argocd-repo-server_patch.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: argocd-repo-server
-        image: quay.io/aicoe/argocd:1.6.1
+        image: quay.io/aicoe/argocd:v1.6.1-1
         env:
         - name: GNUPGHOME
           value: /home/argocd/.gnupg

--- a/manifests/overlays/dev/configs/argo_cm/configManagementPlugins
+++ b/manifests/overlays/dev/configs/argo_cm/configManagementPlugins
@@ -1,0 +1,4 @@
+- name: helmSecrets
+  generate:
+    command: ["/bin/sh", "-c"]
+    args: ["helm secrets template $VALUES_FILES . | sed '/^removed/d'"]

--- a/manifests/overlays/dev/kustomization.yaml
+++ b/manifests/overlays/dev/kustomization.yaml
@@ -14,6 +14,7 @@ configMapGenerator:
   - configs/argo_cm/dex.config
   - configs/argo_cm/kustomize.buildOptions
   - configs/argo_cm/url
+  - configs/argo_cm/configManagementPlugins
 - name: argocd-rbac-cm
   behavior: replace
   files:

--- a/manifests/overlays/prod/configs/argo_cm/configManagementPlugins
+++ b/manifests/overlays/prod/configs/argo_cm/configManagementPlugins
@@ -1,0 +1,4 @@
+- name: helmSecrets
+  generate:
+    command: ["/bin/sh", "-c"]
+    args: ["helm secrets template $VALUES_FILES . | sed '/^removed/d'"]

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -15,6 +15,7 @@ configMapGenerator:
   - configs/argo_cm/resource.exclusions
   - configs/argo_cm/resource.inclusions
   - configs/argo_cm/url
+  - configs/argo_cm/configManagementPlugins
 - name: argocd-rbac-cm
   behavior: replace
   files:


### PR DESCRIPTION
## This introduces a breaking change

- [x] Yes
- [ ] No

## Description

Add helm-secrets plugin to argocd. 

This requires installing sops and helm-secrets. 

The XDG directories are updated to point to `argocd` home directory so the `argocd` user may see the plugin (see [here](https://helm.sh/docs/faq/#xdg-base-directory-support) for more info). This is needed because we install the `helm-secrets` plugin as root, which ends up installing the plugin in the root's home directory. Also, the `helm-secrets` plugin directory needs to be owned by root group so that the anonymously assigned user ID in openshift can use the files created by the plugin in this directory. 
