### PR TITLE
update aicoe-ci repository url

### DIFF
--- a/manifests/overlays/prod/configs/argo_cm/repositories
+++ b/manifests/overlays/prod/configs/argo_cm/repositories
@@ -1,6 +1,8 @@
 - type: git
   url: https://github.com/AICoE/aicoe-cd.git
 - type: git
+  url: https://github.com/AICoE/aicoe-ci.git
+- type: git
   url: https://github.com/AICoE/aicoe-sre.git
 - type: git
   url: https://github.com/AICoE/internal-data-hub.git
@@ -20,6 +22,3 @@
   url: https://github.com/goern/thoth-application.git
 - type: git
   url: https://github.com/thoth-station/thoth-application.git
-- type: git
-  url: https://github.com/thoth-station/thoth-ci.git
-


### PR DESCRIPTION
## Related Issues

Related-to: https://github.com/AICoE/aicoe-ci/issues/58

## This introduces a breaking change

- [x] No

## This Pull Request implements

- update aicoe-ci repository URL

## Description

project is moved to aicoe from thoth-station 
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
