### PR TITLE
Add aiops prod argo

### DIFF
--- a/manifests/overlays/prod/configs/argo_cm/resource.inclusions
+++ b/manifests/overlays/prod/configs/argo_cm/resource.inclusions
@@ -69,9 +69,6 @@
 - apiGroups:
   - argoproj.io
   kinds:
-  - CronWorkflow
-  - Workflow
-  - WorkflowTemplate
   - Application
   - AppProject
   clusters:
@@ -88,6 +85,7 @@
   - Gateway
   - Sensor
   clusters:
+  - https://api.ocp.prod.psi.redhat.com:6443
   - https://paas.stage.psi.redhat.com:443
 - apiGroups:
   - authorization.openshift.io
@@ -331,13 +329,5 @@
   kinds:
   - AirflowBase
   - AirflowCluster
-  clusters:
-  - https://paas.stage.psi.redhat.com:443
-- apiGroups:
-  - argoproj.io
-  kinds:
-  - EventSource
-  - Gateway
-  - Sensor
   clusters:
   - https://paas.stage.psi.redhat.com:443


### PR DESCRIPTION
## Related Issues

Requires: https://github.com/AICoE/internal-data-hub/pull/8,  https://redhat.service-now.com/surl.do?n=RITM0752436

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Re-add the `aiops-prod-argo` namespace on OCP Prod cluster to be watched. Also cleanup the resource inclusion list to allow watching of Argo Events resources on OCP prod (and remove duplicit entries for PaaS Stage)

## Checklist for migrating an Application to ArgoCD

When migrating an application's deployment to be managed by ArgoCD use the following checklist to verify your process.

Items to complete before making a migration PR
- [x] Ensure your application manifests can be built using Kustomize.
- [x] If using secrets, make sure to include the .sops.yaml file in your repository.
- [x] Make sure to create the role granting access to namespace. See [here](cluster_ns_management.md#deploying-to-a-namespace) for more info. This role is tracked in your application manifests.

Items to include within the migration PR
- [x] Ensure your namespace exists in the cluster spec in the [prod-vars.yaml](../vars/prod-vars.yaml) file (for the appropriate cluster).
- [x] If you are switching between ArgoCD managed namespaces, and that namespace was deleted in OCP, then ensure it is also removed from [prod-vars.yaml](../vars/prod-vars.yaml).
- [x] Ensure the application repository is added in the `argo_cm` file in [prod-vars.yaml](../vars/prod-vars.yaml).
- [x] Ensure that all OCP resources that will be managed by ArgoCD on this cluster are included in the `inclusions` list in [prod-vars.yaml](../vars/prod-vars.yaml). See [here](cluster_ns_management.md#cluster-inclusions) for more info.
- [x] Create the ArgoCD Application, see [here](application_management.md) for instructions.
