### PR TITLE
Fix thoth-station graph-backup-job overlay path

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/stage/stage-thoth-graph-backup.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/stage/stage-thoth-graph-backup.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
-    path: graph-backup/overlays/stage
+    path: graph-backup-job/overlays/stage
     targetRevision: master
   destination:
     server: 'https://api.ocp.prod.psi.redhat.com:6443'

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-graph-backup.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-graph-backup.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
-    path: graph-backup/overlays/test
+    path: graph-backup-job/overlays/test
     targetRevision: master
   destination:
     server: 'https://api.ocp.prod.psi.redhat.com:6443'


### PR DESCRIPTION
## This Pull Request implements

Fix thoth-station graph-backup-job overlay path
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## If migrating an Application to ArgoCD
- [x] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
