### PR TITLE
graph-sync ignore auto labels in-sync on specific file

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/stage/stage-thoth-graph-sync-backend.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/stage/stage-thoth-graph-sync-backend.yaml
@@ -16,3 +16,9 @@ spec:
     automated:
       selfHeal: true
       prune: true
+  ignoreDifferences:
+    - group: template.openshift.io
+      kind: Template
+      name: graph-sync-job
+      jsonPointers:
+        - /metadata/labels

--- a/manifests/overlays/prod/applications/thoth-station/stage/stage-thoth-graph-sync-middletier.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/stage/stage-thoth-graph-sync-middletier.yaml
@@ -16,3 +16,9 @@ spec:
     automated:
       selfHeal: true
       prune: true
+  ignoreDifferences:
+    - group: template.openshift.io
+      kind: Template
+      name: graph-sync-job
+      jsonPointers:
+        - /metadata/labels


### PR DESCRIPTION
## This Pull Request implements

graph-sync ignore auto labels in-sync on a specific file
we would like to ignore the difference in labels on a single template file.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## If migrating an Application to ArgoCD
- [x] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
