### PR TITLE
move aicoe-ci from ocp to ocp4 cluster.

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/bots/aicoe-ci.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/bots/aicoe-ci.yaml
@@ -10,7 +10,7 @@ spec:
     path: .
     targetRevision: HEAD
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: aicoe-infra-prod
   syncPolicy:
     automated: {}


### PR DESCRIPTION
## This Pull Request implements

move aicoe-ci from ocp to ocp4 cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## If migrating an Application to ArgoCD
- [X] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
