### PR TITLE
Aiops prod argo ocp4

### DIFF
--- a/manifests/overlays/prod/applications/aiops/aiops-prod-argo.yaml
+++ b/manifests/overlays/prod/applications/aiops/aiops-prod-argo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   destination:
     namespace: aiops-prod-argo
-    server: https://api.ocp.prod.psi.redhat.com:6443
+    server: https://api.ocp4.prod.psi.redhat.com:6443
   project: aiops
   source:
     path: argo/overlays/aiops-prod-argo
@@ -25,7 +25,7 @@ metadata:
 spec:
   destination:
     namespace: aiops-prod-argo
-    server: https://api.ocp.prod.psi.redhat.com:6443
+    server: https://api.ocp4.prod.psi.redhat.com:6443
   project: aiops
   source:
     path: argo-events/overlays/aiops-prod-argo

--- a/manifests/overlays/prod/applications/aiops/argo-analytics.yaml
+++ b/manifests/overlays/prod/applications/aiops/argo-analytics.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   destination:
     namespace: aiops-prod-argo
-    server: https://api.ocp.prod.psi.redhat.com:6443
+    server: https://api.ocp4.prod.psi.redhat.com:6443
   project: aiops
   source:
     path: manifests

--- a/manifests/overlays/prod/configs/argo_cm/resource.inclusions
+++ b/manifests/overlays/prod/configs/argo_cm/resource.inclusions
@@ -92,11 +92,11 @@
   - WorkflowTemplate
   clusters:
   - https://api.ocp.prod.psi.redhat.com:6443
+  - https://api.ocp4.prod.psi.redhat.com:6443
 - apiGroups:
   - argoproj.io
   kinds:
-  - Application
-  - AppProject
+  - WorkflowEventBinding
   clusters:
   - https://api.ocp4.prod.psi.redhat.com:6443
 - apiGroups:
@@ -365,14 +365,6 @@
   - https://datahub.psi.redhat.com:443
   - https://paas.stage.psi.redhat.com:443
 - apiGroups:
-  - argoproj.io
-  kinds:
-  - CronWorkflow
-  - Workflow
-  - WorkflowTemplate
-  clusters:
-  - https://api.ocp4.prod.psi.redhat.com:6443
-- apiGroups:
   - extensions
   kinds:
   - Ingress
@@ -441,17 +433,5 @@
   kinds:
   - AirflowBase
   - AirflowCluster
-  clusters:
-  - https://paas.stage.psi.redhat.com:443
-- apiGroups:
-  - argoproj.io
-  kinds:
-  - CronWorkflow
-  - EventBus
-  - EventSource
-  - Gateway
-  - Sensor
-  - Workflow
-  - WorkflowTemplate
   clusters:
   - https://paas.stage.psi.redhat.com:443

--- a/manifests/overlays/prod/secrets/clusters/api.ocp4.prod.psi.redhat.com.enc.yaml
+++ b/manifests/overlays/prod/secrets/clusters/api.ocp4.prod.psi.redhat.com.enc.yaml
@@ -10,15 +10,15 @@ type: Opaque
 stringData:
     name: api.ocp4.prod.psi.redhat.com
     config: ENC[AES256_GCM,data:bufxayqcBzenOFXBozlqPeVGcFjPUMo+QJ9nY9nBnlitkyXynKwdFKhE6A01fFmEjwGMuXA/vuFozVgCoGZ9dfayK9MbVdCZPYtcXvV3wlScrWj8fDPFwrENND8C/IIKUBk0DZeLbUwVC9IGRitb/nwUFq697ElTE8OePRYGRUpxENNFshKL2eN7H9S7UvwPhMQTIs5T7J+E7hjT3bp7sURBOKalqe89TyJCfseou4GeAg1ZSHbxETvszwNFXVzFNFZ7zi/uD353VkAklk6CFWyUUx5c3R/8OOntzyk6D5akSpfNHMuIBCNcPnHxSYmgXrkiT8Majks7T6fajXcgAVh6OEuPGt1/bY4iGpU9KG7iFcDueg/a83952rBqv12VueMTaX8eJIVk9OCbEZ/HdOETgBOKlEAbG2CquR3NSoaRP6BPt0MkaeShcHddwdkWCRjDyQgbcD/p8NIH6UXdVQI4swi0l7gNCLvSm35TtRNAaC5Cb5w6awPrbcXSmwE/hS8oO4dNxalu6zo4LfeL8eywlqV0RJSmAwUWmA4OYl4wa1qnPIz6j7kce/NXHW6ro+0QsZoNLJnu2kCc+ZiLuW7evWJbYbPpFt1JDg/cQ8pmGKhbLzjmSJvnDRL/Lu29K1xadj2f+zvuoipEwx9Uf0Njsm2Gr/N7VIabgiUFSSt2ppEwz+KPkNdY+jqt1I9c4as+P+DVv9kcmV7vUaohfgR4PfpFAkO+Dt+8MLRTbppMDFBmOE4aG/v0zY9wwzY/I/tmDAMZayikGI6qIAYuyVBGZpc6M8T30BeHzgW5u0to1cGYWXf1YXjYiac8hrfFITNdFW8kr7LKEumh/5U1Gb4stsJ47PJdT1OJk6E5+rNLqTxLbSXczcU5QUPyu8a6/Y/Gctx34728ALbUg1hUm2luAjNqK0abfh4h72Dw0sI4U0G3JCwOXr4512ZvT2CgzVNeW8NGtEwPY7xdab3ksnabQRPa7rxwJ4I4FR28Gof3DSR/rdZBYO8hP+fKZcRKAt5vu5Rvsanu+/kvkzfhhoy7VHHbXG1MTDt6C/05pNpHhA07Kdt9vmjlYIJjiH/sphUtlC7IoJ92sCSZCh0lbvJfu3KGSnVO4mY9/Tyd6N7D/aDih90otJA84LJGhQjLTEUDQ8Ged5qtxkZ4nLSCHl9uG8GM3BG2BPrkuGAcWo+pslbjkSk+Qhs5pPM0yi5F9dxc5qOQ+MDd1Yv+IaBskbj+kABM9JsSOQV8CspWvB0/daU24Z4kFhkLC5vhL5ABcDT+HT0p9YqVdjgPGiaEC/H/zHA6npHC4w2J1Z04crtfBV7Jl3Z4+Q==,iv:Wzgdp22L0//sccbZ75O6yTj89t2c7iNnbHZFGPE6c9A=,tag:cLN+pi5oeoLxVFwkaH+fnw==,type:str]
-    namespaces: aicoe-argocd,dh-psi-monitoring,dtuchyna-thoth-dev,fpokorny-thoth-dev,kpostlet-thoth-dev,thoth-amun-api-stage,thoth-amun-inspection-stage,thoth-backend-stage,thoth-frontend-stage,thoth-graph-stage,thoth-infra-stage,thoth-middletier-stage,thoth-test-core,aicoe-prod-bots,aicoe-infra-prod
+    namespaces: aicoe-argocd,dh-psi-monitoring,dtuchyna-thoth-dev,fpokorny-thoth-dev,kpostlet-thoth-dev,thoth-amun-api-stage,thoth-amun-inspection-stage,thoth-backend-stage,thoth-frontend-stage,thoth-graph-stage,thoth-infra-stage,thoth-middletier-stage,thoth-test-core,aicoe-prod-bots,aicoe-infra-prod,aiops-prod-argo
     server: https://api.ocp4.prod.psi.redhat.com:6443
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-10-19T14:12:30Z'
-    mac: ENC[AES256_GCM,data:4n2vrUjMmXgbVYg3EaZ5EiBdP/pED9El5ipLU2+BkIeSBfjVI5TXKJRCOSsmy8UrXYVvvBT94Vzmyj+3M5pnzkAk/d04Dq0RDSLgAyVGT7h83IVhjmUhM/1J91Qxld7yO1vqGhI/GAmcXmQCiYBJtSdXwb8yygNzWNd3FtiHlkc=,iv:dtNa5XIEEHct6a65ZAF2tGStPRDGVDWYHVHTHvMyxoo=,tag:iyN0IQu5Oz6KxR/uOUiDtg==,type:str]
+    lastmodified: '2020-10-19T14:53:37Z'
+    mac: ENC[AES256_GCM,data:+rNyvWkOXJdqhNUDQMS5lj5opAZfWKUVQpxPqRhp8eIHzgt6BmLyWFKld0WU66n6box/IIK9guYOEsztSFaZESy6qDiP7kg0mOUYFyxco+dCuk2LVuXWcervhBUjY4DQ+0bROTDJidZW62ycCsO2YDS7K4fkvk9pXXD7OChBnK8=,iv:o1nQJWuIIt1/xjNSlTELBx8G+EAHlZNIglzNo6WqssY=,tag:b3okiG1/ExHXMDEZ1qVzuQ==,type:str]
     pgp:
     -   created_at: '2020-10-19T14:12:29Z'
         enc: |
@@ -36,4 +36,4 @@ sops:
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(config)$
-    version: 3.6.0
+    version: 3.6.1


### PR DESCRIPTION
## This Pull Request implements

Migrate `aiops-prod-argo` to OCP4 cluster

The argo-cd role was deployed in the target namespace, all CRDs exists on the target cluster.

Along with this PR I've consolidated and cleaned up the resource inclusion list for `argoproj.io` group. We had 4 resource group entries to describe 3 clusters. Now we're down to 2 clusters, expected to go down to 1 soon. Also the resources in `argoproj.io` group watched in both clusters are nearly the same - except ocp cluster is missing one CRD (`workfloweventbindings`). The consolidated result are [on lines 81-101](https://github.com/tumido/aicoe-cd/blob/72b7e7a300ed4ea5b64956e67e06c6326b4892be/manifests/overlays/prod/configs/argo_cm/resource.inclusions#L81-L101) of the resource inclusion list.

