### PR TITLE
Update sa token for old ocp4 cluster

### DIFF
--- a/manifests/overlays/prod/secrets/clusters/apps.ocp.prod.psi.redhat.com.enc.yaml
+++ b/manifests/overlays/prod/secrets/clusters/apps.ocp.prod.psi.redhat.com.enc.yaml
@@ -9,30 +9,30 @@ metadata:
 type: Opaque
 stringData:
     name: apps.ocp.prod.psi.redhat.com
-    config: ENC[AES256_GCM,data:rmxie9sfSJEF8by0xx5QIw/laFzpZq+5CHiSSXUmb1T5zGefsveOoKdq+EYVWomauN96keWYErxHnQIJCbPKw9do7gNo3/ITjCaSIkrVCU/55qdys+3l48MJkcdKu5GCfiSHtUqr362+a/ZCa62XoXTcg805xUXq7wlCO8esJesWgY11h27l56UwgK7QARWQrlw3CbArfxwX05R/lA1MfyVRc+xF/vMTfOFChkN6hbdBbf/dO4ukRExqxCdJHjkzVZNIjxk/jBtnX/wDo0nRR4FfSp7L2+EF2BlSf4rFRZFNARydKV23D3vbjiVILnJpzqNnAL2Fidvy9bEwytTtKwd5Ng7dgHCkhhrzLl8j+ozGABbBUhFyJQkA28k6QARy8O31o6InArBmAwR2kFLRAzryw7/pxrqmAXz04LB8qQnnL53Z4QTgLoloR1fxNsko/Fi+9e8dMgOEbKw3GMjLzp54pDmI0BfpVGqqWuuTvkC/bGCW2UroABUuNSQYToaCcA846bjbt1R6ynxKl+105gFiph5z9lcKnG14/sIOEQzeHbvL6SBHsT6NRJHYnQp3N7a7fdmq06sbwVACb/houUQFYxg1olXbjxNpS9wUqCYAKCCFPaQPBsPGwxkn9XmjMUfdnaH+voj3LUuKcyj+PLwtVhto8vTEZx1H6r1VPCKU9pyOoBWAqoRXvHuq43UoIIUJ0PwxY45qS0o/H7Hcaw6uTTAVp0o16rmFSMS24BOiTvffr8nJBT2jhc5aFsySaEuaoaPvDQNqmF7OjQDjHFP0rf21nM74mbN9ifzyHUlPbAj1gYgibAgY0lqd/tWYJqR8b7j0Z8PXYyt2yUOYy92BvEpLzl0PB2SJUG4FWiHvcjMAx5eDZ221bY9C5gKSSB/5sEf+1H06jckKVIIahm4Esipxdz3nnPlQ/bKHxGzoIuBphRq03N2Y1grASt9sH/BphNfyZ6dKfws8gHs5AVMY2v76fBOm94lQLS8BTgd3M5d4Wk2CnJhjD5T1ygLgAWWk+njv7dIKfKmzWkpermTONcI/Ur8oPtkUfHr6dJswTyK47pkQ5njHIKXj3QVKP/cg0WzYJNQ0lT9AJtr07NNFyazhfmlDbiE+PIXnZY5dgKvRJ9N3l5VByk8LMaGm9TqbkLIGEvRh4EO5fhcOWmpU3sYtpcKw0Rkk0SHHEDM34omQ8QPFEcM1CejHc9tsSOynm06gWjz2aopeZz53C3jFNBc/f0QW0Q0KhHPgnVSI5xzrVjGwioRD+MT+HYo4nuBLDuIsV0JZ6A5P0PrIFPJq+zgMzuWkMC4L+2wUBheK054Ae58UxA==,iv:42i7s45KpmOLMUpRKPExMbH/VQyB5ymVBOUNza+TCPE=,tag:OPSQMDgkFNv2euTt+r4h7Q==,type:str]
-    namespaces: aicoe-argocd,dh-psi-monitoring,dtuchyna-thoth-dev,fpokorny-thoth-dev,kpostlet-thoth-dev,thoth-amun-api-stage,thoth-amun-inspection-stage,thoth-backend-stage,thoth-frontend-stage,thoth-graph-stage,thoth-infra-stage,thoth-middletier-stage,thoth-test-core,aicoe,aicoe-prod-bots,aiops-prod-argo,aicoe-infra-prod
+    config: ENC[AES256_GCM,data:eNBHTeEnIb/V0hMaupgEQEN8KapFRQYU2sD7KsDfVNMwbIjxaQMnodDT/pFjSZ5JsmEEEt9EFd/BHslAHyOvR4et+eYzkQ3q42drmMxapRa6nkZrNTT3K6MdclMUNqz4ZUt8fFk4oWk7wMXx8imshDDJB2iaChUn0/VzrEBiXvsMvcabwtHZhcJHq6DqhMQJfoCCkt2HG0+e4SfMLN7rGVyjd1+LJAqbeUHBxL31k6gyDp2A6HhAo5XaazXnEsfQYsDZ4ABw0tmJ16F77WWRV7t/ov/zixcrZR/EQKWWLujl7H3cCe281r36T88reIMBmpL4kK0v+/vMKGDimIut6nFNDQS4ubY8ygyCxjjvo6k3+emzFK5uQkkabu1LzV/fp+n1QzyAvPRHg+7NLiWJ/T1PY7NCQU8LVZcxHLpzCese7Ds/sXnMz3+HTa3nvV4P+HnRDrfuq7LFJYDjqnhEXarfjN2hHJutF9uPowx4KbUhvQcZp3vOvPkS9r6tYO3zxC1PQ5p1jr0BIrQmqOSxPDsgwV1Loxh8at7FENpSYW68dlvW371e23dwu0no7bgjnTffNajLAZ13c/1FK4yB6igUcOGpuZnbaIRjFmMv5FZYqKvp7jSjdkYK6+oBAB5ML+6Z/u6b5G1iLJJy3siOxIY4TeYuPoXTvtZiccQETHbs7QlxTNqUJIPOWO8WNKvO4vWoeRqIydTQRhFJffgmR46PsI2km6DvbEBSiwBZhou79EHxw+yuuCNvE2KSa5sO3VPj6c7SI06xhLeio9a3wbyGLep44+f9zu4e5Y2gW3tcaQsu6fb0dbEl71YhvQ3Dg2hh4qRJX8WKg0TW3x0gDnixiiHe84Vm60An59WoWR60YELb6OPLsUpZPDysda0w2+cNuEfJQMbi3902VYrorIxFiAzzDo6PO1Me9GT0IYnkrXtWw7jyxWm5gPrb6q5JCKY6lnjUtJbSc4CXbnOpj7t5zhZppixpPygf+fpfKO559mMQN8Ikt62p1UU0zQIvoZZRNz/IOMl4QcMZRvNt06R0ahfEakHurwHYDKejg+kozw/FAD7qzKXBzkvHPYzV5sJpCj+3L7Pez2ojIyjrIDhPoiOu+IHg2Jyo6SfLsqb+y1Rb2eD0dezy/cqosN2zDQ890n7B3dNq/HZxF5lFfIHbvjb4IA37CG2Kx7bJVKIIULGDOW8L0I/1UO+publ3mfMszky/Q2BUmw7EF2WvH+QL+2ywYNYl68rU5IfKPXqiG4JtPOXXGEkYzKBSdLtzlLJUAbII81Z4Lul/+/GCfwEGFpuh0rP04OsfA5fb8Cve4eidPVvMpvxVwWvI09fpd8gjSs4kXsXewRUInA==,iv:K4BgrBgQ/bzHzCfxDVybmwYIlmpAJNW423nFdyrNnHQ=,tag:g7FGkS5/uGrW8W2/8+mm6A==,type:str]
+    namespaces: dtuchyna-thoth-dev,fpokorny-thoth-dev,kpostlet-thoth-dev,thoth-amun-api-stage,thoth-amun-inspection-stage,thoth-backend-stage,thoth-frontend-stage,thoth-graph-stage,thoth-infra-stage,thoth-middletier-stage,thoth-test-core,aicoe,aicoe-prod-bots,aiops-prod-argo,aicoe-infra-prod
     server: https://api.ocp.prod.psi.redhat.com:6443
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-10-19T14:12:52Z'
-    mac: ENC[AES256_GCM,data:9Kr1zpS2QkjqQokO3zgoFqHh8QjVaRolkgJRSnU0S1wwuf7+XB6Qcp9KLKqvESE2CcjhssDCeslq0zrPPRk8b5tNO+v+LRMDoFIw8ygSc1uMPLG3GfvcC0VWzIe4mcm+kYxWg466CtvHy8ntn0r6fyYEDC+hpawUFA9K5mx7tJQ=,iv:y9OSd91Ly8YIPdbrb4CKsO3JN6v0t/34DEd433JksP8=,tag:t8OD5dDK3bthkkPDZtBYyQ==,type:str]
+    lastmodified: '2020-10-20T17:08:02Z'
+    mac: ENC[AES256_GCM,data:JrUYCUqT+xBKEBL2UyFCNIzZf+Qu/LGObuE0vVpCh9NjlkOD+6S6FhC4ozOPWvNtFqYwZh49UbtpnVapVw1lLoERX13OeqJlapDiauh/iGwO4RGl+7LKUDObyF1Tcx+BHbjlGO9VPChIP9KhFhHUqeRHjfo+lDAgM9yPMo3FD0o=,iv:h42JfMRqXzopS0TVWtdc3yrVWMqjxZ6YCpLtWnvZ7b4=,tag:J1zPiyAfMP7iPg6cy5Yj1A==,type:str]
     pgp:
-    -   created_at: '2020-10-19T14:12:52Z'
+    -   created_at: '2020-10-20T17:08:01Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf9E9yjGUBZ0hFIx77/aFLMDVCsfjOYVlqOOwEBcps4eVnL
-            LKR8DrAZzcRkrUzhMqlON57XoiJMqGhmmtFqLyZaV3axDcj5C1vmbVNDL6Qscnuj
-            0rBJH5AhuTbxAa3LtdnLpcyPXNQHHd1MHOHRKKwXrD1ytt/MnjufIUGx8u624FGK
-            2WRAA/7HwSWBneQyurjv4DHcliv2BsVZ7ZugP30FMkU4vurR0kBzFFBVgrMqhhr8
-            0cYC/YN1m9j51lN37t5PtBDhpkkW8y4/94m5GQu0hcvUrolheKrxKobhc9IDimnY
-            W6nbov4YBJiW9c4SegrjJHKXu22qIomDrlY1eAuSn9JeAX/5QvN5oNj76LiVMKC/
-            oJxLWm6LDcV68lnvR1HcFxS5UX6/yKDWQubV+lgBI6+PWD2vWN7qG6F3V3yDEQCK
-            7c9++TAXFi/ozskD/p+oC2l5JMNRClukXadlkqX+tA==
-            =/O8m
+            hQEMA/irrHa183bxAQgAlZnKHfcMASrnb4Qf3oZHIXpgz9bIWnXx4ahcQpSyC3uL
+            nv35p1TaS1Ng2isNul+aBEyAWeVfQc972CbpLyASqP0c9G2HxHTbGS33RMXeHOzc
+            oXOndJFSRpwNfp+W6KnxB8xtZ3VupD+U9W3pwHdIIz0QvjQoOQSFKfJH+m2L6Zwa
+            BkXO7rdGxrGVzvW4LduWBKnMiWsw/e4cVMGgvO/gyvMIoSmfOAzOGm9D/U+52tC1
+            WTTQoYnOFopa9aiDeM8tBMHDAhcnbRcfZ+Ht8gYWx4U6aVnKEv9XTZ4SIfVcdRZS
+            2jTrXCGxsiCmjQutu0lhQeXecfEZwJt8eNQoZtdoYdJeAZGyWd+fyU2+WZUUpyHF
+            I6Fa0DYG2y+ZzyVt42mqtBQPr6udE4LEsc+0FiNPrxH+zWFE3Y+qgnlO8S/o7vmz
+            j0eg/7oQpTRTS10fzYRQv5iUL45oYeLSveqxj+b+ow==
+            =41OT
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(config)$


### PR DESCRIPTION
Old sa in aicoe-argocd was deleted, new sa was created in aicoe-argocd-manager namespace, this pr updates the token information for the cluster to point to the new sa in the new namespace, we'll use this sa until this cluster is decommissioned from here on. 