### PR TITLE
Remove nonexistent resources from 3.11 inclusions list

### DIFF
--- a/manifests/overlays/prod/configs/argo_cm/resource.inclusions
+++ b/manifests/overlays/prod/configs/argo_cm/resource.inclusions
@@ -433,7 +433,6 @@
   - AlamedaRecommendation
   - AlamedaScaler
   clusters:
-  - https://datahub.psi.redhat.com:443
   - https://paas.stage.psi.redhat.com:443
   - https://k-openshift.osh.massopen.cloud:8443/
 - apiGroups:


### PR DESCRIPTION
Looks like some crds part of the autoscaling.containers.ai apigroup were deleted from the 3.11 cluster, need to remove these from our resource `inclusions` list so that ArgoCD does not try to look for them. 