### PR TITLE
fix the thoth-station ocp4 deployment with standard ids

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/core-backend.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/core-backend.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-core-backend
+  name: ocp4-stage-thoth-core-backend
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/core-frontend.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/core-frontend.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-core-frontend
+  name: ocp4-stage-thoth-core-frontend
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/core-graph.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/core-graph.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-core-graph
+  name: ocp4-stage-thoth-core-graph
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/core-infra.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/core-infra.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-core-infra
+  name: ocp4-stage-thoth-core-infra
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/core-middletier.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/core-middletier.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-core-middletier
+  name: ocp4-stage-thoth-core-middletier
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-advise-reporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-advise-reporter.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-advise-reporter
+  name: ocp4-stage-thoth-advise-reporter
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-adviser.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-adviser.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-adviser
+  name: ocp4-stage-thoth-adviser
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-amun-api.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-amun-api.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-amun-api
+  name: ocp4-stage-thoth-amun-api
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-amun-inspection.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-amun-inspection.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-amun-inspection
+  name: ocp4-stage-thoth-amun-inspection
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-chat-notification.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-chat-notification.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-chat-notification
+  name: ocp4-stage-thoth-chat-notification
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-cve-update.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-cve-update.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-cve-update
+  name: ocp4-stage-thoth-cve-update
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-backup.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-backup.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-graph-backup
+  name: ocp4-stage-thoth-graph-backup
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-refresh.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-refresh.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-graph-refresh
+  name: ocp4-stage-thoth-graph-refresh
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-backend.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-backend.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-graph-sync-backend
+  name: ocp4-stage-thoth-graph-sync-backend
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-middletier.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-middletier.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-graph-sync-middletier
+  name: ocp4-stage-thoth-graph-sync-middletier
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-investigator.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-investigator.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-investigator
+  name: ocp4-stage-thoth-investigator
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-kebechet.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-kebechet.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-kebechet
+  name: ocp4-stage-thoth-kebechet
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-management-api.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-management-api.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-management-api
+  name: ocp4-stage-thoth-management-api
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-metrics-exporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-metrics-exporter.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-metrics-exporter
+  name: ocp4-stage-thoth-metrics-exporter
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-mi.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-mi.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-mi
+  name: ocp4-stage-thoth-mi
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-package-extract.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-package-extract.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-package-extract
+  name: ocp4-stage-thoth-package-extract
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-package-releases.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-package-releases.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-package-releases
+  name: ocp4-stage-thoth-package-releases
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-package-update.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-package-update.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-package-update
+  name: ocp4-stage-thoth-package-update
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-qeb-hwt.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-qeb-hwt.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-qeb-hwt
+  name: ocp4-stage-thoth-qeb-hwt
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-revsolver.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-revsolver.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-revsolver
+  name: ocp4-stage-thoth-revsolver
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-security-indicators.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-security-indicators.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-security-indicators
+  name: ocp4-stage-thoth-security-indicators
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-slo-reporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-slo-reporter.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-slo-reporter
+  name: ocp4-stage-thoth-slo-reporter
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-solver.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-solver.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-solver
+  name: ocp4-stage-thoth-solver
 spec:
   project: thoth-stage
   source:

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-user-api.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-user-api.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stage-thoth-user-api
+  name: ocp4-stage-thoth-user-api
 spec:
   project: thoth-stage
   source:


### PR DESCRIPTION
## This Pull Request implements

fix the thoth-station ocp4 deployment with standard ids
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## If migrating an Application to ArgoCD
- [x] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
