### PR TITLE
feat: Add argocd-admin role with access to apps, make template role read only

### DIFF
--- a/manifests/overlays/prod/configs/argo_rbac_cm/policy.csv
+++ b/manifests/overlays/prod/configs/argo_rbac_cm/policy.csv
@@ -1,17 +1,14 @@
-p, role:argocd-admin, certificates, get, *, allow
-p, role:argocd-admin, certificates, create, *, allow
-p, role:argocd-admin, certificates, update, *, allow
-p, role:argocd-admin, clusters, get, *, allow
-p, role:argocd-admin, clusters, create, *, allow
-p, role:argocd-admin, clusters, update, *, allow
-p, role:argocd-admin, repositories, get, *, allow
-p, role:argocd-admin, repositories, create, *, allow
-p, role:argocd-admin, repositories, update, *, allow
-p, role:argocd-admin, projects, get, *, allow
-p, role:argocd-admin, projects, create, *, allow
-p, role:argocd-admin, projects, update, *, allow
-p, role:argocd-admin, accounts, get, *, allow
-p, role:argocd-admin, accounts, update, *, allow
+p, role:argocd-template, certificates, get, *, allow
+p, role:argocd-template, clusters, get, *, allow
+p, role:argocd-template, repositories, get, *, allow
+p, role:argocd-template, projects, get, *, allow
+p, role:argocd-template, accounts, get, *, allow
+
+p, role:argocd-admin, applications, get, */*, allow
+p, role:argocd-admin, applications, sync, */*, allow
+g, aicoe-argocd-admins, role:argocd-admin
+g, aicoe-argocd-admins, role:argocd-template
+g, data-hub-openshift-admins, role:argocd-admin
 
 p, role:thoth-admin, applications, get, thoth/*, allow
 p, role:thoth-admin, applications, update, thoth/*, allow
@@ -34,7 +31,7 @@ p, role:thoth-admin, applications, delete, thoth-dev/*, allow
 p, role:thoth-admin, applications, sync, thoth-dev/*, allow
 p, role:thoth-admin, applications, override, thoth-dev/*, allow
 p, role:thoth-admin, applications, action/*, thoth-dev/*, allow
-g, aicoe-thoth-devops, role:argocd-admin
+g, aicoe-thoth-devops, role:argocd-template
 g, aicoe-thoth-devops, role:thoth-admin
 
 p, role:data-hub-admin, applications, get, data-hub/*, allow
@@ -51,7 +48,7 @@ p, role:data-hub-admin, applications, delete, data-hub-dev/*, allow
 p, role:data-hub-admin, applications, sync, data-hub-dev/*, allow
 p, role:data-hub-admin, applications, override, data-hub-dev/*, allow
 p, role:data-hub-admin, applications, action/*, data-hub-dev/*, allow
-g, data-hub-openshift-admins, role:argocd-admin
+g, data-hub-openshift-admins, role:argocd-template
 g, data-hub-openshift-admins, role:data-hub-admin
 
 p, role:aiops-admin, applications, get, aiops/*, allow
@@ -60,5 +57,5 @@ p, role:aiops-admin, applications, delete, aiops/*, allow
 p, role:aiops-admin, applications, sync, aiops/*, allow
 p, role:aiops-admin, applications, override, aiops/*, allow
 p, role:aiops-admin, applications, action/*, aiops/*, allow
-g, aicoe-aiops-devops, role:argocd-admin
+g, aicoe-aiops-devops, role:argocd-template
 g, aicoe-aiops-devops, role:aiops-admin


### PR DESCRIPTION
## This Pull Request implements

As @anishasthana pointed out https://github.com/AICoE/aicoe-cd/pull/189/files/704dc0366b63ac873ff9303ad47d1f0ca7e2654a#r532583546 `argocd-admins` should have access to all applications. Let's add a generic rule for that.

