### PR TITLE
fix: Add missing dex groups

### DIFF
--- a/manifests/overlays/prod/configs/argo_cm/dex.config
+++ b/manifests/overlays/prod/configs/argo_cm/dex.config
@@ -13,3 +13,5 @@ connectors:
         - data-hub-openshift-admins
         - aicoe-thoth-devops
         - aicoe-aiops-devops
+        - aicoe-argocd-admins
+        - aicoe-ccx


### PR DESCRIPTION
## This Pull Request implements

With #189  and #191 I forgot to enable those groups in DEX config, so it doen't allow them to log in.

/cc @HumairAK @anishasthana 