### PR TITLE
feat: Add IDH Argo/Argo Events

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-prod-argo.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-argo.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo.dh-prod-argo
+spec:
+  destination:
+    namespace: dh-prod-argo
+    server: https://datahub.psi.redhat.com:443
+  project: data-hub
+  source:
+    path: argo/overlays/dh-prod-argo
+    repoURL: https://github.com/AICoE/idh-manifests.git
+    targetRevision: production
+  syncPolicy:
+    syncOptions:
+      - Validate=false
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-events.dh-prod-argo
+spec:
+  destination:
+    namespace: dh-prod-argo
+    server: https://datahub.psi.redhat.com:443
+  project: data-hub
+  source:
+    path: argo-events/overlays/dh-prod-argo
+    repoURL: https://github.com/AICoE/idh-manifests.git
+    targetRevision: production
+  syncPolicy:
+    syncOptions:
+      - Validate=false

--- a/manifests/overlays/prod/applications/data_hub/dh-stage-argo.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-stage-argo.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo.dh-stage-argo
+spec:
+  destination:
+    namespace: dh-stage-argo
+    server: https://datahub.psi.redhat.com:443
+  project: data-hub
+  source:
+    path: argo/overlays/dh-stage-argo
+    repoURL: https://github.com/AICoE/idh-manifests.git
+    targetRevision: production
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-events.dh-stage-argo
+spec:
+  destination:
+    namespace: dh-stage-argo
+    server: https://datahub.psi.redhat.com:443
+  project: data-hub
+  source:
+    path: argo-events/overlays/dh-stage-argo
+    repoURL: https://github.com/AICoE/idh-manifests.git
+    targetRevision: production
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/manifests/overlays/prod/applications/data_hub/kustomization.yaml
+++ b/manifests/overlays/prod/applications/data_hub/kustomization.yaml
@@ -17,3 +17,5 @@ resources:
 - dh-prod-customer-journeys.yaml
 - dh-stage-superset.yaml
 - dh-prod-superset.yaml
+- dh-stage-argo.yaml
+# - dh-prod-argo.yaml  # FIXME: Unlisted until dh-stage-argo verifies the migration success


### PR DESCRIPTION
## This Pull Request implements

Migrate DH argo deployments from Ansible to Argo CD/kustomize using the same manifests already used by `aiops-prod-argo`. 

:warning: Requires manual cleanup in the namespaces first probably. :warning: 

## If migrating an Application to ArgoCD
- [x] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
