### PR TITLE
move thoth test apps from ocp4.3 to ocp4.5

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/test/core-test.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/core-test.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-core
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: core/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-advise-reporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-advise-reporter.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-advise-reporter
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: advise-reporter/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-adviser.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-adviser.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-adviser
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: adviser/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-amun.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-amun.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-amun
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: amun/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-chat-notification.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-chat-notification.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-chat-notification
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: chat-notification/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-cve-update.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-cve-update.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-cve-update
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: cve-update/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-graph-backup.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-graph-backup.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-graph-backup
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: graph-backup-job/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-graph-refresh.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-graph-refresh.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-graph-refresh
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: graph-refresh/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-graph-sync.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-graph-sync.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-graph-sync
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: graph-sync/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-investigator.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-investigator.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-investigator
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: investigator/overlays/test
     targetRevision: HEAD
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-kebechet.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-kebechet.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-kebechet
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: kebechet/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-management-api.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-management-api.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-management-api
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: management-api/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-metrics-exporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-metrics-exporter.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-metrics-exporter
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: metrics-exporter/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-mi-scheduler.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-mi-scheduler.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-mi-scheduler
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: mi-scheduler/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-package-extract.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-package-extract.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-package-extract
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: package-extract/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-package-releases.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-package-releases.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-package-releases
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: package-releases/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-package-update.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-package-update.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-package-update
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: package-update/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-qeb-hwt.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-qeb-hwt.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-qeb-hwt
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: qeb-hwt-github-app/overlays/test
     targetRevision: HEAD
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-revsolver.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-revsolver.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-revsolver
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: revsolver/overlays/test
     targetRevision: HEAD
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-security-indicators.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-security-indicators.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-security-indicators
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: security-indicators/overlays/test
     targetRevision: HEAD
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-slo-reporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-slo-reporter.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-slo-reporter
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: slo-reporter/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-solver.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-solver.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-solver
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: solver/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-user-api.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-user-api.yaml
@@ -4,13 +4,13 @@ kind: Application
 metadata:
   name: test-thoth-user-api
 spec:
-  project: thoth
+  project: thoth-dev
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
     path: user-api/overlays/test
     targetRevision: master
   destination:
-    server: 'https://api.ocp.prod.psi.redhat.com:6443'
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
     namespace: thoth-test-core
   syncPolicy:
     automated: {}


### PR DESCRIPTION
## This Pull Request implements

move thoth test apps from ocp4.3 to ocp4.5
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


## If migrating an Application to ArgoCD
- [x] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
