### PR TITLE
feat: Add prod solgate

### DIFF
--- a/manifests/overlays/prod/applications/aiops/kustomization.yaml
+++ b/manifests/overlays/prod/applications/aiops/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - argo-analytics.yaml
   - aiops-prod-argo.yaml
   - argo-anomaly.yaml
+  - solgate.yaml

--- a/manifests/overlays/prod/applications/aiops/solgate.yaml
+++ b/manifests/overlays/prod/applications/aiops/solgate.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: solgate
+spec:
+  destination:
+    namespace: aiops-prod-argo
+    server: https://api.ocp4.prod.psi.redhat.com:6443
+  project: aiops
+  source:
+    path: manifests/overlays/prod
+    repoURL: https://github.com/aicoe-aiops/sync-pipelines.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/manifests/overlays/prod/configs/argo_cm/repositories
+++ b/manifests/overlays/prod/configs/argo_cm/repositories
@@ -34,3 +34,5 @@
   url: https://gitlab.cee.redhat.com/psilling/insights-rules-statistics.git
   insecure: true
   insecureIgnoreHostKey: true
+- type: git
+  url: https://github.com/aicoe-aiops/sync-pipelines.git


### PR DESCRIPTION
## This Pull Request implements

Add solgate sync pipelines to ArgoCD - currently list it under AiOps project while it runs in `aiops-prod-argo` namespace. When a migration to `dh-prod-argo` is possible (with https://github.com/AICoE/idh-manifests/pull/62 merged), it should be moved to datahub project.

/cc @anishasthana @martinpovolny @HumairAK 