### PR TITLE
Revert "Upgrade ArgoCD to 1.8.1"

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github.com/operate-first/continuous-deployment/manifests/base?ref=v1.8.1-1
+- github.com/operate-first/continuous-deployment/manifests/base?ref=v1.7.4-3

--- a/manifests/crds/kustomization.yaml
+++ b/manifests/crds/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github.com/operate-first/continuous-deployment/manifests/crds?ref=v1.8.1-1
+- github.com/operate-first/continuous-deployment/manifests/crds?ref=v1.7.4-1

--- a/manifests/overlays/prod/deployments/argocd-application-controller_patch.yaml
+++ b/manifests/overlays/prod/deployments/argocd-application-controller_patch.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: argocd-application-controller
 spec:
@@ -8,6 +8,7 @@ spec:
     spec:
       containers:
       - name: argocd-application-controller
+        image: quay.io/aicoe/argocd:v1.7.4-3
         resources:
           limits:
             memory: 8Gi

--- a/manifests/overlays/prod/deployments/argocd-dex-server_patch.yaml
+++ b/manifests/overlays/prod/deployments/argocd-dex-server_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-dex-server
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-dex-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-dex-server
+    spec:
+      initContainers:
+      - image: 'quay.io/operate-first/argocd:v1.7.4'
+        imagePullPolicy: Always
+        name: copyutil
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      serviceAccountName: argocd-dex-server
+      volumes:
+      - name: static-files

--- a/manifests/overlays/prod/deployments/argocd-redis_patch.yaml
+++ b/manifests/overlays/prod/deployments/argocd-redis_patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-redis
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-redis
+    spec:
+      containers:
+      - image: quay.io/internaldatahub/redis:5.0.8
+        name: redis

--- a/manifests/overlays/prod/deployments/argocd-server_patch.yaml
+++ b/manifests/overlays/prod/deployments/argocd-server_patch.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-server
+spec:
+  template:
+    spec:
+      containers:
+      - image: quay.io/aicoe/argocd:v1.7.4-3
+        name: argocd-server

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -28,4 +28,7 @@ generators:
 - secrets/clusters/secret-generator.yaml
 patchesStrategicMerge:
 - serviceaccounts/argocd-dex-server.yaml
-- statefulsets/argocd-application-controller_patch.yaml
+- deployments/argocd-application-controller_patch.yaml
+- deployments/argocd-server_patch.yaml
+- deployments/argocd-redis_patch.yaml
+- deployments/argocd-dex-server_patch.yaml


### PR DESCRIPTION
This reverts commit 7c0e72e7680890059ce486bba96aef8ca4a57c2c.

The upgrade resulted in ArgoCD in an unhealthy state due to a number of errors. We are reverting the changes for now and will attempt the upgrade again at a later date. 
