### PR TITLE
Increase replica count for repo_server & exec timeout

### DIFF
--- a/manifests/overlays/prod/deployments/argocd-repo-server_patch.yaml
+++ b/manifests/overlays/prod/deployments/argocd-repo-server_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-repo-server
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: argocd-repo-server
+          env:
+            - name: ARGOCD_EXEC_TIMEOUT
+              value: 180

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -32,3 +32,4 @@ patchesStrategicMerge:
 - deployments/argocd-server_patch.yaml
 - deployments/argocd-redis_patch.yaml
 - deployments/argocd-dex-server_patch.yaml
+- deployments/argocd-repo-server_patch.yaml


### PR DESCRIPTION
This patch increases replica count for repo-server, it also increases the `ARGOCD_EXEC_TIMEOUT` to avoid manifest generation time out errors. This solution is presented  [here](ARGOCD_EXEC_TIMEOUT)