### PR TITLE
Fix repo server timout env var to string

### DIFF
--- a/manifests/overlays/prod/deployments/argocd-repo-server_patch.yaml
+++ b/manifests/overlays/prod/deployments/argocd-repo-server_patch.yaml
@@ -10,4 +10,4 @@ spec:
         - name: argocd-repo-server
           env:
             - name: ARGOCD_EXEC_TIMEOUT
-              value: 180
+              value: "180"


### PR DESCRIPTION
Apparently the quotations are important for env vars. 