### PR TITLE
Optimize repo server

### DIFF
--- a/manifests/overlays/prod/deployments/argocd-repo-server_patch.yaml
+++ b/manifests/overlays/prod/deployments/argocd-repo-server_patch.yaml
@@ -3,11 +3,21 @@ kind: Deployment
 metadata:
   name: argocd-repo-server
 spec:
-  replicas: 2
+  replicas: 4
   template:
     spec:
       containers:
         - name: argocd-repo-server
+          command:
+            - uid_entrypoint.sh
+            - argocd-repo-server
+            - '--redis'
+            - 'argocd-redis:6379'
+            - '--parallelismlimit'
+            - '3'
           env:
             - name: ARGOCD_EXEC_TIMEOUT
-              value: "300"
+              value: "600"
+          resources:
+            limits:
+              memory: 1Gi


### PR DESCRIPTION
The repo server seems to be hitting memory limit which causes manifest generation to fail, leaving apps in an "unknown" state and giving errors like `rpc error: code = Unknown desc = Manifest generation error` or `Context deadline exceeded`, the following patch introduces the following changes: 

- Limit memory of each pod to 1Gi
- Increase replica count for repo server to 4, (1Gi per pod)
- Limit concurrent manifest generation (i.e. git clone/kustomize builds etc.) for each repo-server pod to only 3 at a time 
