### PR TITLE
Scale up app controller

### DIFF
--- a/manifests/overlays/prod/statefulsets/argocd-application-controller_patch.yaml
+++ b/manifests/overlays/prod/statefulsets/argocd-application-controller_patch.yaml
@@ -4,10 +4,11 @@ kind: StatefulSet
 metadata:
   name: argocd-application-controller
 spec:
+  replicas: 4
   template:
     spec:
       containers:
       - name: argocd-application-controller
         resources:
           limits:
-            memory: 8Gi
+            memory: 2Gi


### PR DESCRIPTION
Distribute the app-controller's memory usage onto separate replicas, this will also enable sharding and distribute cluster workload onto different replicas. 