### PR TITLE
Turn off autosync for app of apps

### DIFF
--- a/manifests/overlays/prod/applications/argocd/argocd-apps.yaml
+++ b/manifests/overlays/prod/applications/argocd/argocd-apps.yaml
@@ -12,8 +12,5 @@ spec:
     repoURL: https://github.com/AICoE/aicoe-cd.git
     targetRevision: HEAD
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - Validate=false


### PR DESCRIPTION
When argocd  autosyncs an app, it will evaluate all resouces in that repo. Even if you change 1 file, it will also evaluate all other resources. Where as when sync'ing from the UI, you can select to sync only "OutOfSync" resources, which can be considerably faster. Right now there is no way to make it so that autosync will only sync "OutOfSync" resources. See [here](https://github.com/argoproj/argo-cd/issues/3877). This feature is targeted for the next 1.9 release (we're on 1.8). 


Now because of this, our app-of-apps repo uses up a lot of memory when running autosync, but it syncs relatively fast when just _Syncing_ only _OutofSync_ resources. Currently we have each app-controller replica limited to 2Gi of memory, but with more apps being onboarded, our `app-of-apps` app requires more than 2Gi to sync, while most of the other applications require considerably less memory. It does not make sense to increase the replica memory usage for just one app (huge waste of resources). So the suggestion is: 

Turn off autosync for this app for now (and any other extremely large apps using more than 2Gi of memory, atm I think this is the only one). When new apps are added, just manually sync only "OutOfSync" resources. Once 1.9 is out, we'll turn autosync back on. 