### PR TITLE
Disable auto-sync for Stage Applications

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-stage-argo.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-stage-argo.yaml
@@ -32,8 +32,5 @@ spec:
     repoURL: https://github.com/AICoE/idh-manifests.git
     targetRevision: production
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - Validate=false

--- a/manifests/overlays/prod/applications/data_hub/dh-stage-jupyterhub.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-stage-jupyterhub.yaml
@@ -12,8 +12,5 @@ spec:
     repoURL: https://github.com/AICoE/idh-manifests.git
     targetRevision: production
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
     - Validate=false

--- a/manifests/overlays/prod/applications/data_hub/dh-stage-kafka.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-stage-kafka.yaml
@@ -17,8 +17,5 @@ spec:
         - name: VALUES_FILES
           value: "-f secrets.enc.yaml -f helm_vars/stage/secrets.yaml -f helm_vars/stage/values.yaml"
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - Validate=false

--- a/manifests/overlays/prod/applications/data_hub/dh-stage-logstash.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-stage-logstash.yaml
@@ -12,8 +12,5 @@ spec:
     repoURL: https://github.com/AICoE/internal-data-hub.git
     targetRevision: master
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
     - Validate=false

--- a/manifests/overlays/prod/applications/data_hub/dh-stage-rsyslog.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-stage-rsyslog.yaml
@@ -12,8 +12,5 @@ spec:
     repoURL: https://github.com/AICoE/internal-data-hub.git
     targetRevision: master
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
     - Validate=false


### PR DESCRIPTION
This PR is disabling auto-sync for Data Hub stage apps so that we can scale down apps as needed

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>
