### PR TITLE
Ignore Jupyterhub route annotation

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-prod-jupyterhub.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-jupyterhub.yaml
@@ -14,3 +14,9 @@ spec:
   syncPolicy:
     syncOptions:
     - Validate=false
+  ignoreDifferences:
+  - group: route.openshift.io/v1
+    kind: Route
+    name: jupyterhub
+    jsonPointers:
+    - /metadata/annotations


### PR DESCRIPTION
This is due to a bug with ksops on kustomize 3.9. The bug results in `"` being removed from annotations, so Argocd thinks there is a difference between the live manifest and what is in git.