### PR TITLE
Remove autosync from ocp4-anomaly app

### DIFF
--- a/manifests/overlays/prod/applications/aiops/argo-anomaly.yaml
+++ b/manifests/overlays/prod/applications/aiops/argo-anomaly.yaml
@@ -12,14 +12,5 @@ spec:
     repoURL: https://github.com/aicoe-aiops/ocp4-anomaly-detection-internal.git
     targetRevision: master
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - Validate=false
-  ignoreDifferences:
-    - group: batch
-      kind: CronJob
-      name: anomaly-detect-collector
-      jsonPointers:
-        - /spec/template/spec/containers/0/image


### PR DESCRIPTION
So #229 is not enough here, there are other mismatches  in the diff which I believe are unrelated to the image issue described here #230. For now let's just keep this app's auto sync turned off.

Fields having diff issues in this app:

```
spec.jobTemplate.concurrencyPolicy
```

```
spec.containters.[0].image 
```


```
resources.limits.cpu
```