### PR TITLE
Allocate clusters to appropriate shards

### DIFF
--- a/manifests/overlays/prod/secrets/clusters/api.ocp4.prod.psi.redhat.com.enc.yaml
+++ b/manifests/overlays/prod/secrets/clusters/api.ocp4.prod.psi.redhat.com.enc.yaml
@@ -12,13 +12,14 @@ stringData:
     config: ENC[AES256_GCM,data:bufxayqcBzenOFXBozlqPeVGcFjPUMo+QJ9nY9nBnlitkyXynKwdFKhE6A01fFmEjwGMuXA/vuFozVgCoGZ9dfayK9MbVdCZPYtcXvV3wlScrWj8fDPFwrENND8C/IIKUBk0DZeLbUwVC9IGRitb/nwUFq697ElTE8OePRYGRUpxENNFshKL2eN7H9S7UvwPhMQTIs5T7J+E7hjT3bp7sURBOKalqe89TyJCfseou4GeAg1ZSHbxETvszwNFXVzFNFZ7zi/uD353VkAklk6CFWyUUx5c3R/8OOntzyk6D5akSpfNHMuIBCNcPnHxSYmgXrkiT8Majks7T6fajXcgAVh6OEuPGt1/bY4iGpU9KG7iFcDueg/a83952rBqv12VueMTaX8eJIVk9OCbEZ/HdOETgBOKlEAbG2CquR3NSoaRP6BPt0MkaeShcHddwdkWCRjDyQgbcD/p8NIH6UXdVQI4swi0l7gNCLvSm35TtRNAaC5Cb5w6awPrbcXSmwE/hS8oO4dNxalu6zo4LfeL8eywlqV0RJSmAwUWmA4OYl4wa1qnPIz6j7kce/NXHW6ro+0QsZoNLJnu2kCc+ZiLuW7evWJbYbPpFt1JDg/cQ8pmGKhbLzjmSJvnDRL/Lu29K1xadj2f+zvuoipEwx9Uf0Njsm2Gr/N7VIabgiUFSSt2ppEwz+KPkNdY+jqt1I9c4as+P+DVv9kcmV7vUaohfgR4PfpFAkO+Dt+8MLRTbppMDFBmOE4aG/v0zY9wwzY/I/tmDAMZayikGI6qIAYuyVBGZpc6M8T30BeHzgW5u0to1cGYWXf1YXjYiac8hrfFITNdFW8kr7LKEumh/5U1Gb4stsJ47PJdT1OJk6E5+rNLqTxLbSXczcU5QUPyu8a6/Y/Gctx34728ALbUg1hUm2luAjNqK0abfh4h72Dw0sI4U0G3JCwOXr4512ZvT2CgzVNeW8NGtEwPY7xdab3ksnabQRPa7rxwJ4I4FR28Gof3DSR/rdZBYO8hP+fKZcRKAt5vu5Rvsanu+/kvkzfhhoy7VHHbXG1MTDt6C/05pNpHhA07Kdt9vmjlYIJjiH/sphUtlC7IoJ92sCSZCh0lbvJfu3KGSnVO4mY9/Tyd6N7D/aDih90otJA84LJGhQjLTEUDQ8Ged5qtxkZ4nLSCHl9uG8GM3BG2BPrkuGAcWo+pslbjkSk+Qhs5pPM0yi5F9dxc5qOQ+MDd1Yv+IaBskbj+kABM9JsSOQV8CspWvB0/daU24Z4kFhkLC5vhL5ABcDT+HT0p9YqVdjgPGiaEC/H/zHA6npHC4w2J1Z04crtfBV7Jl3Z4+Q==,iv:Wzgdp22L0//sccbZ75O6yTj89t2c7iNnbHZFGPE6c9A=,tag:cLN+pi5oeoLxVFwkaH+fnw==,type:str]
     namespaces: aicoe-argocd,dh-prod-ingest,dh-psi-monitoring,thoth-amun-api-stage,thoth-amun-inspection-stage,thoth-backend-stage,thoth-frontend-stage,thoth-graph-stage,thoth-infra-stage,thoth-middletier-stage,thoth-test-core,aicoe-prod-bots,aicoe-infra-prod,aiops-prod-argo
     server: https://api.ocp4.prod.psi.redhat.com:6443
+    shard: 1
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-11-03T18:40:00Z'
-    mac: ENC[AES256_GCM,data:CrSW4AjxjvkKurcM1msAJU0wYRO/LAqmZSR64c5tOtUtmqM02wv1YXuhMSGKnIE3m+O2n4WwLraM3BQTUUpcnsIR4BVGZs4cRhZERRQxfMRpFSMMJOkSuK0CLGVgz37ca5MPV0U3OSfpRNuMoRue7WRhTdvP7FJeuAIeCi5krBo=,iv:sxCa4p068AgezCgDdUtzNpdH/VFznnQ0UUXzYnhiORA=,tag:57JIc5hbbH6eXWygGPqTuQ==,type:str]
+    lastmodified: '2021-01-28T20:15:51Z'
+    mac: ENC[AES256_GCM,data:pSin/jr2tXrW6BznFBxtRwvcXx4Ec/hYpcLJhayrR3KrObMeyrMkxlLw+3eW7DBDgVlTUCOTXUZFqzczOFje9xJEsAHGrPOzQgtVcagXWX7c8Jx9oFMMxuv9V8a3XmrGYWYQFqLGJwCulEoVH4nfl/30eMqJFTDcKFzKtsPnxag=,iv:Hp1jvDlyYArjoL8dbJY8fS0b7cnw8lCEIE3sVKdTF74=,tag:QFti2w3pVskLTnqiGyNHGw==,type:str]
     pgp:
     -   created_at: '2020-10-19T14:12:29Z'
         enc: |

--- a/manifests/overlays/prod/secrets/clusters/apps.ocp.prod.psi.redhat.com.enc.yaml
+++ b/manifests/overlays/prod/secrets/clusters/apps.ocp.prod.psi.redhat.com.enc.yaml
@@ -12,13 +12,14 @@ stringData:
     config: ENC[AES256_GCM,data:eNBHTeEnIb/V0hMaupgEQEN8KapFRQYU2sD7KsDfVNMwbIjxaQMnodDT/pFjSZ5JsmEEEt9EFd/BHslAHyOvR4et+eYzkQ3q42drmMxapRa6nkZrNTT3K6MdclMUNqz4ZUt8fFk4oWk7wMXx8imshDDJB2iaChUn0/VzrEBiXvsMvcabwtHZhcJHq6DqhMQJfoCCkt2HG0+e4SfMLN7rGVyjd1+LJAqbeUHBxL31k6gyDp2A6HhAo5XaazXnEsfQYsDZ4ABw0tmJ16F77WWRV7t/ov/zixcrZR/EQKWWLujl7H3cCe281r36T88reIMBmpL4kK0v+/vMKGDimIut6nFNDQS4ubY8ygyCxjjvo6k3+emzFK5uQkkabu1LzV/fp+n1QzyAvPRHg+7NLiWJ/T1PY7NCQU8LVZcxHLpzCese7Ds/sXnMz3+HTa3nvV4P+HnRDrfuq7LFJYDjqnhEXarfjN2hHJutF9uPowx4KbUhvQcZp3vOvPkS9r6tYO3zxC1PQ5p1jr0BIrQmqOSxPDsgwV1Loxh8at7FENpSYW68dlvW371e23dwu0no7bgjnTffNajLAZ13c/1FK4yB6igUcOGpuZnbaIRjFmMv5FZYqKvp7jSjdkYK6+oBAB5ML+6Z/u6b5G1iLJJy3siOxIY4TeYuPoXTvtZiccQETHbs7QlxTNqUJIPOWO8WNKvO4vWoeRqIydTQRhFJffgmR46PsI2km6DvbEBSiwBZhou79EHxw+yuuCNvE2KSa5sO3VPj6c7SI06xhLeio9a3wbyGLep44+f9zu4e5Y2gW3tcaQsu6fb0dbEl71YhvQ3Dg2hh4qRJX8WKg0TW3x0gDnixiiHe84Vm60An59WoWR60YELb6OPLsUpZPDysda0w2+cNuEfJQMbi3902VYrorIxFiAzzDo6PO1Me9GT0IYnkrXtWw7jyxWm5gPrb6q5JCKY6lnjUtJbSc4CXbnOpj7t5zhZppixpPygf+fpfKO559mMQN8Ikt62p1UU0zQIvoZZRNz/IOMl4QcMZRvNt06R0ahfEakHurwHYDKejg+kozw/FAD7qzKXBzkvHPYzV5sJpCj+3L7Pez2ojIyjrIDhPoiOu+IHg2Jyo6SfLsqb+y1Rb2eD0dezy/cqosN2zDQ890n7B3dNq/HZxF5lFfIHbvjb4IA37CG2Kx7bJVKIIULGDOW8L0I/1UO+publ3mfMszky/Q2BUmw7EF2WvH+QL+2ywYNYl68rU5IfKPXqiG4JtPOXXGEkYzKBSdLtzlLJUAbII81Z4Lul/+/GCfwEGFpuh0rP04OsfA5fb8Cve4eidPVvMpvxVwWvI09fpd8gjSs4kXsXewRUInA==,iv:K4BgrBgQ/bzHzCfxDVybmwYIlmpAJNW423nFdyrNnHQ=,tag:g7FGkS5/uGrW8W2/8+mm6A==,type:str]
     namespaces: thoth-amun-api-stage,thoth-amun-inspection-stage,thoth-backend-stage,thoth-frontend-stage,thoth-graph-stage,thoth-infra-stage,thoth-middletier-stage,thoth-test-core,aicoe,aicoe-prod-bots,aiops-prod-argo,aicoe-infra-prod
     server: https://api.ocp.prod.psi.redhat.com:6443
+    shard: 1
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-11-03T18:39:33Z'
-    mac: ENC[AES256_GCM,data:yuOEgqFjlVhg02ckRtxVV6vqR1rDXsDDvcPyUMuDp4QbTexlNCIHjMR+nKwL6+Uy8QF2pb268tumCqozwNlN4ru2yllGD+1/jGl/5o3/Jw59v/ynTggqOoEdSmBCCpVfPRgV/3SzNebNRZIwYX8KORf8EZIiNtyXmY/LxadLgns=,iv:yWsREvA0eIwi+ZrlbE/kd7HeuKcSoaZLK86Le1VY8lw=,tag:pobJ4EaNFDld01s8j2Zupg==,type:str]
+    lastmodified: '2021-01-28T20:16:01Z'
+    mac: ENC[AES256_GCM,data:fCt2gbUAGkMwGwIhSWp9VP5nlv/1jLb4Vg8Mr1UIek+yhNzSPT+W6NlXdCnh6ks+DgOCuKTCilqQeZL1RjaQmL1yurEiFr/WiaGJwaXgocJeSKhBf7xNIGG11+vPEQM2/LAFfXUTIlyN+rcJ18vYNpvZ47Pqy7QA5VqgEj19vmk=,iv:kry7GGCA5Fyc4G6xDWz9shaiErEoDD66nL+f647R5lg=,tag:33ORQRSsJ+4JuImdMfW9dg==,type:str]
     pgp:
     -   created_at: '2020-10-20T17:08:01Z'
         enc: |
@@ -36,4 +37,4 @@ sops:
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(config)$
-    version: 3.6.0
+    version: 3.6.1

--- a/manifests/overlays/prod/secrets/clusters/datahub.psi.redhat.com.enc.yaml
+++ b/manifests/overlays/prod/secrets/clusters/datahub.psi.redhat.com.enc.yaml
@@ -12,12 +12,14 @@ stringData:
     config: ENC[AES256_GCM,data:CGSsQ8vTGpMALg2+E3mUwc1HpR3Vek+idXQDQN6COeGgYA3X1PNMZNhRPFZvU9Uqn9MAJUQaRo3DiDFkQ9SI7ySaQS48JOueIEinSP9qd2dLZPO0U+QkyrBGPkPC41/W63JieAWtTMPViA/B8zjfNhv1PMyrK0ySu0TiEWfo+99CeQSVkkv6e7WAEufjCN1El4MoP1j/+TgrTPLgUImT/TXp/chPFUwZLqWKvlQnmIW+3ZG/S7gkO+H4ur9w4wn4k1OfRtfApD4BHX/XFS/OLjaI6fhH6D/U9M7+1IZyfVo4SAL9rKUzYiIQ+FiKQfc6ADC5Hb4HX9cXHPCUsZLIcN3Dm+FBGUiTDF2Cit6CXiINDoscoNgsBWR3RCfXf25dxfKalXhagZ/ALh54xYPkFHbwB92Xw07mwXIDhSACbsQLQwu9f/RxuxSRW1CymnS2m0CaySes1ZTkSGkDNNd28pY8vxNu9OaTt6wP6SgqWXMpqus+LAjRgPzEVu+URiN1FRMI85twBRfX9xLpIWkopjEf/9KdTWC5DbnRLw5f6e6W7IgmpwC+QwDF3IulD09JfkY4p0bf1Own+CUdqP/U/dQrm4q4LvHkswcqvZWJvM1fYEB4tTIFSvmV6NuzRfMRIs/ykht3NJKLmiTH8kNzPuIc3wpj0kkGxdC+6qmyCn44n0Iu/etEbJ+aRE5JEID1DnBqJznoufmSC+AwzyRKq6CTaotbhIBSFz0lhYWSRRY/na9ns31xL9wIuf/v37HoLlqy6SQH3uRisRJR61wdAg4dI9cP+vZJS/kwVUU/c3IPBcwxzhjoRNVu52R22cmUtQoNJgFDTW5Lg/zVtTngQIzLqc0iooXowXHFQv1UcCcld+M0PMGQdlsVb4qVAcUN8z3Q7tYJNaI2xGP+5oFFZa8w2fmamREzbQwXGBBmE2FaW8cZilbjlqU2XDHI35sI2gn5uYhO7aDhgl1YDEM0yd+1FQwKREodpzQDOglViF97VlxftKLNfWq2ghdWe0sZWmbpt46CB/0vzZOSceaSnAV/CLYV4Y1EeprRAgJT6DeqCRbHGTQjFZd7ym3w5MfWvdUJKJ+O+y/aCYWKEI46eChn34chXI4W9IY5yB5lcJoTtD71apC36Nc0caepo1UPzlCJ6vr4A/0YtdDIT3ixwiD7iqpK6XQc5oKtsgX7qbCoYSNxaNWP+5ZPrYW6R1FRNuyQwEEwH0/AKD8d30aaDQpy1dYQRLMTsKTTczxvjw2AUso=,iv:u0wWP5y+GlAO2MsCaeZtiS7/kKGsRiy1lF0BBJJGsNU=,tag:+EnXUNYwF59eLmgXIjd9Tw==,type:str]
     namespaces: dh-prod-jupyterhub,dh-prod-message-bus,dh-prod-ingest,dh-prod-analytics-factory,dh-prod-data-catalog-usir,dh-prod-data-catalog-ccx,dh-prod-customer-journeys,dh-prod-superset,dh-prod-argo
     server: https://datahub.psi.redhat.com:443
+    shard: 0
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2021-01-21T20:04:04Z'
-    mac: ENC[AES256_GCM,data:Os/NGd7EOM4oqeOE8potfLDEEs30ZWsJmeTFXueQZtCw/cNPnblHcHAzvb/DTvHrlinQlC6J419g81WgC++2oyGg/bZ0PBUM4+WvlFPM6t87ZeC4xTq9oavgPRCZZbiI8jz6QFZMMUN0PEvrSmcXrS8xxyrq7UoWnGtTmj4ZCXA=,iv:lru6czPsjCPd11/WvZkqb2bYrmLeDJRCgfDSzwCa1zM=,tag:74oo/mA0VP3C3nqI7XrhjA==,type:str]
+    hc_vault: []
+    lastmodified: '2021-01-28T20:15:28Z'
+    mac: ENC[AES256_GCM,data:kcJEGb9kqIjm3CCW3shbNpsM6K/TpWQq7mlM5MMDZoNl+upmEv3LGkUba3Q3cP8ZOgcjWZEXKOnaYLZNob3OCEvaxqzKuYfP9tn+QcTYD5IF5vzjuG9oP+bVU23xK1fF6DlEbSl9mKmTxVLh146sQ+KHsNuxENCMUlUKfjLNvQw=,iv:fynC7vVNmQBhFBcHmIp/RU8M1aUhay9EiwFotxpDhuY=,tag:S3p7HJkzPdN0wuy/nwaYWg==,type:str]
     pgp:
     -   created_at: '2020-08-10T01:26:30Z'
         enc: |

--- a/manifests/overlays/prod/secrets/clusters/paas.stage.psi.redhat.com.enc.yaml
+++ b/manifests/overlays/prod/secrets/clusters/paas.stage.psi.redhat.com.enc.yaml
@@ -12,12 +12,14 @@ stringData:
     config: ENC[AES256_GCM,data:VCLAzJI24C78EEBMfN/bQ2+HKxTxXyDjWS4lp6VuYC1KVSRW/7fVeHojUfl4o/HypAzRnBByZ9lO98rgsTZxDAbHzpnSxstkuERhV7CgUbJ1jySIYCpS5YR401guwqyVKiwt88rXTRmP07Ddl+qfcNym1pkmw05q7bYh5J1jiI7rkTcNZzod1DGznNryk/nTHPa5RXtinpJgQjnUyi1xmY/6PoT3Vuc8IoT2GC3FY6sXonGHkKjljs8Oh2R4zUfWzWeIYAE06sb0ZrTdLc06Ojqa/bh+GPM28roJa/96QRS16KS01YuZXYmgAgQwdOKTuyqHRw5TXVdStetHcwew/wJonf9OKfP5n4LF5IH/cplVkg/u/U0i+3GcSG4D9pHUicMNSf2EAPsrPgZcf3Xx/XVewV//tgfFt/+DB0YhzYlBXQG6F2Kpr1gzv6Sa340NfrBhrv8wljYylTwdpYQSJb72py9q+VUjh3Pu18XBaIfuwwVBvka1CEK25b8ulYdSCF5+YYMAiKZZiVyVYHdkaIkttBOxiNmPwmRechByxVt52R0y+CLfNE3SEVFvBdwj1/xvEhtQqGRXN+iA9rUOszmK5xwg3XRL2lVLCwsnH2x6xeNSwT+sri53f9uwHla3QfypCbPP1YgYliR5e6dr6wS4ftk4eoIVvnRdsOxXZVA3QjNjRLuBEmHe3aGPC8gMs+1Y6VHXtttIx+qgeJH/ppvsKUBCPY22OVNDiC2bWCH1iOAwtAUV3S3keP2cfmvLpnzFn4se8l3vqLGatk8ofC2gFa7KzitoSx4mTBNy3vw8D5SWGkJW62gdlZMyM4yyyhwa56xEzhgpXvA0XJUjR105TCZa9U7ZU7Jh5Dhq+u6BHJzMb0naayZSOewlb84lGeSZpRSOI3e9y7aKC2IkOogVj4GEFbcxMW6Z7HfgYVmxSmw2QF1aLrbhpWkO63hP73qQXYkzYKhln65RFKgPuavAPRe9Q0wyo7+GkMGx1KJ+sVFvPHUBH1nMjchwKQmXdVEhGkcSqDtXIK0B9Ziol7YhFZnYWxEPPOWDk7WcItVZGA0hpZSiVdit0hj4C/wCg1mSolZCeqjCmkgML3BnZrJ5IqvxFlB3IxTe7SXFvYRZopXJALgDlhgaaeVLx5z9kMAZNiqYI6yQw3x/p7WJvJWjVlenY6u21QzU1w1Y5KdiVYEQhYw/SNsR8z7aHESTIx6PDSEDbqWsE0KUb+0Fjlfx3NQaTFBQPnRrkI6sWZ1ixlQ=,iv:4tnHCEUasLXqvkxUM4PgzlCLirZwf+yHKWSz6At15hE=,tag:RwKW3AU1EzouW1KZ+UWrCg==,type:str]
     namespaces: dh-stage-jupyterhub,dh-stage-message-bus,dh-stage-ingest,dh-stage-analytics-factory,dh-stage-superset,dh-stage-argo
     server: https://paas.stage.psi.redhat.com:443
+    shard: 0
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2021-01-14T19:42:19Z'
-    mac: ENC[AES256_GCM,data:CePl7opgOhyp2nqJvbJ5wzZQNxj/yu7JgSl5Tiv6LK4xHB4bAFWcNmeY6XGKseC57G9uTXKwhEIP27EG1PsPOL3ex9MACa+7j2EtNh9T2GmBTqiIGJZyoFb40+0O/CtLeBkmp1S8SMdVeNsIRc9aa49O4U2fQ0CMrb0e+269yvg=,iv:VVWTGIlQ9CbOQldaZ1jPVVqZQWdAX60LokHNCdPuhP0=,tag:wZlHjtPF8MhLcjrUbDY81Q==,type:str]
+    hc_vault: []
+    lastmodified: '2021-01-28T20:15:08Z'
+    mac: ENC[AES256_GCM,data:Z01vxI7e4K183iW11AIC9Ws0pV+R245jJqgxsLNmAZLMQb1cAxJI+fPRM+Hc7UdR/IIT5tI6d0pvucLamFtclxN8ABFzHEoqMNQ//J18oyNTgXgybK/Bhe9hh2wTzV+x9s11J3WobL1ZFEJXrTYkrHMUdObmX3Od04kdw3/Kw4U=,iv:umV0oSQiJksbg0ipwVjA/XOVDubckpTIN/VwLodnaao=,tag:tJqna9QvUpWMhV0cEmE7jA==,type:str]
     pgp:
     -   created_at: '2020-08-10T01:26:35Z'
         enc: |


### PR DESCRIPTION
This part is documented only in the[ swagger spec](https://github.com/argoproj/argo-cd/blob/master/assets/swagger.json#L4909) for cluster secrets, but we can allocate clusters to specific shards, this should help distribute the workload more than it does currently. 