### PR TITLE
Include thoth integration tests app setup manifests

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/kustomization.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - stage-thoth-graph-schema-update.yaml
 - stage-thoth-graph-sync-backend.yaml
 - stage-thoth-graph-sync-middletier.yaml
+- stage-thoth-integration-tests.yaml
 - stage-thoth-investigator.yaml
 - stage-thoth-kebechet.yaml
 - stage-thoth-management-api.yaml

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-integration-tests.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-integration-tests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ocp4-stage-thoth-integration-tests
+spec:
+  project: thoth-stage
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: integration-tests/overlays/ocp4-stage
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
+    namespace: thoth-infra-stage
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+    - Validate=false
+  ignoreDifferences:
+  - group: batch
+    kind: CronJob
+    name: integration-tests
+    jsonPointers:
+    - /spec/jobTemplate/spec/template/spec/containers/0/image

--- a/manifests/overlays/prod/applications/thoth-station/test/kustomization.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - test-thoth-graph-schema-update.yaml
 - test-thoth-graph-refresh.yaml
 - test-thoth-graph-sync.yaml
+- test-thoth-integration-tests.yaml
 - test-thoth-investigator.yaml
 - test-thoth-kebechet.yaml
 - test-thoth-management-api.yaml

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-integration-tests.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-integration-tests.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-thoth-integration-tests
+spec:
+  project: thoth-dev
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: integration-tests/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}
+    syncOptions:
+    - Validate=false
+  ignoreDifferences:
+  - group: batch
+    kind: CronJob
+    name: integration-tests
+    jsonPointers:
+    - /spec/jobTemplate/spec/template/spec/containers/0/image


### PR DESCRIPTION
## This Pull Request implements

Include thoth integration tests app setup manifests
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/thoth-station/thoth-application/pull/899

## If migrating an Application to ArgoCD
- [x] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
