### PR TITLE
Remove argo-events from dh-prod-thanos-extractor

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-prod-thanos-extractor.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-thanos-extractor.yaml
@@ -14,20 +14,3 @@ spec:
   syncPolicy:
     syncOptions:
       - Validate=false
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: argo-events.dh-prod-thanos-extractor
-spec:
-  destination:
-    namespace: dh-prod-thanos-extractor
-    server: https://datahub.psi.redhat.com:443
-  project: data-hub
-  source:
-    path: argo-events/overlays/dh-prod-thanos-extractor
-    repoURL: https://github.com/AICoE/idh-manifests.git
-    targetRevision: production
-  syncPolicy:
-    syncOptions:
-      - Validate=false


### PR DESCRIPTION
## This Pull Request implements

argo-events no longer used in dh-prod-thanos-extractor, so remove it.


## If migrating an Application to ArgoCD
- [ ] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
