### PR TITLE
Ignore image diff in all Data Hub data catalog apps

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-prod-analytics-factory.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-analytics-factory.yaml
@@ -14,3 +14,19 @@ spec:
   syncPolicy:
     syncOptions:
     - Validate=false
+  ignoreDifferences:
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    name: hue-mysql
+    jsonPointers:
+    - /spec/template/spec/containers/0/image
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    name: thriftserver
+    jsonPointers:
+    - /spec/template/spec/initContainers/0/image
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    name: thriftserver-postgres
+    jsonPointers:
+    - /spec/template/spec/containers/1/image

--- a/manifests/overlays/prod/applications/data_hub/dh-prod-data-catalog-ccx.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-data-catalog-ccx.yaml
@@ -14,3 +14,19 @@ spec:
   syncPolicy:
     syncOptions:
     - Validate=false
+  ignoreDifferences:
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    name: hue-mysql
+    jsonPointers:
+    - /spec/template/spec/containers/0/image
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    name: thriftserver
+    jsonPointers:
+    - /spec/template/spec/initContainers/0/image
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    name: thriftserver-postgres
+    jsonPointers:
+    - /spec/template/spec/containers/1/image

--- a/manifests/overlays/prod/applications/data_hub/dh-prod-data-catalog-usir.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-data-catalog-usir.yaml
@@ -14,3 +14,19 @@ spec:
   syncPolicy:
     syncOptions:
     - Validate=false
+  ignoreDifferences:
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    name: hue-mysql
+    jsonPointers:
+    - /spec/template/spec/containers/0/image
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    name: thriftserver
+    jsonPointers:
+    - /spec/template/spec/initContainers/0/image
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    name: thriftserver-postgres
+    jsonPointers:
+    - /spec/template/spec/containers/1/image

--- a/manifests/overlays/prod/applications/data_hub/dh-stage-analytics-factory.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-stage-analytics-factory.yaml
@@ -15,17 +15,17 @@ spec:
     syncOptions:
     - Validate=false
   ignoreDifferences:
-  - group: apps
+  - group: apps.openshift.io
     kind: DeploymentConfig
     name: hue-mysql
     jsonPointers:
     - /spec/template/spec/containers/0/image
-  - group: apps
+  - group: apps.openshift.io
     kind: DeploymentConfig
     name: thriftserver
     jsonPointers:
     - /spec/template/spec/initContainers/0/image
-  - group: apps
+  - group: apps.openshift.io
     kind: DeploymentConfig
     name: thriftserver-postgres
     jsonPointers:


### PR DESCRIPTION
In testing the dh-stage-analytics-factory app we found that the diff wasn't properly being ignored. We believe this is due to the object group being apps.openshift.io and not apps. I'm optimistic that this change will make it work, so I'm applying it to all of the other data hub data catalog apps as well.