### PR TITLE
support thoth-station prod integration test application via argocd

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/prod/kustomization.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/prod/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- bots
-- test
-- ocp4-stage
-- prod
+- prod-thoth-integration-tests.yaml

--- a/manifests/overlays/prod/applications/thoth-station/prod/prod-thoth-integration-tests.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/prod/prod-thoth-integration-tests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prod-thoth-integration-tests
+spec:
+  project: thoth-stage
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: integration-tests/overlays/cnv-prod-ocp4-stage
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
+    namespace: thoth-frontend-stage
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+    - Validate=false
+  ignoreDifferences:
+  - group: batch
+    kind: CronJob
+    name: integration-tests
+    jsonPointers:
+    - /spec/jobTemplate/spec/template/spec/containers/0/image


### PR DESCRIPTION
## This Pull Request implements

support thoth-station prod integration test application via argocd
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## If migrating an Application to ArgoCD
- [x] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
