### PR TITLE
Add SLO-reporter prod run from stage

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/prod/kustomization.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/prod/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- prod-slo-reporter.yaml
 - prod-thoth-integration-tests.yaml

--- a/manifests/overlays/prod/applications/thoth-station/prod/prod-slo-reporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/prod/prod-slo-reporter.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prod-thoth-slo-reporter
+spec:
+  project: thoth-stage
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: slo-reporter/overlays/zero-prod-ocp4-stage
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
+    namespace: aicoe-prod-bots
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+    - Validate=false
+  ignoreDifferences:
+  - group: batch
+    kind: CronJob
+    name: slo-reporter
+    jsonPointers:
+    - /spec/jobTemplate/spec/template/spec/containers/0/image


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Related to: https://github.com/thoth-station/thoth-application/pull/1038
## This Pull Request implements

Add application for SLO reporter prod run from stage in aicoe-prod-bots namespace.

## If migrating an Application to ArgoCD
- [x] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
