### PR TITLE
Add dh-{stage,prod}-trino in kustomization.yaml

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/kustomization.yaml
+++ b/manifests/overlays/prod/applications/data_hub/kustomization.yaml
@@ -21,3 +21,5 @@ resources:
 - dh-prod-thanos-extractor.yaml
 - dh-stage-rhods-catalog.yaml
 - dh-stage-rhods-objects.yaml
+- dh-stage-trino.yaml
+- dh-prod-trino.yaml


### PR DESCRIPTION
## This Pull Request implements

Add dh-{stage,prod}-trino in kustomization.yaml

## If migrating an Application to ArgoCD
- [X] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
