### PR TITLE
fix: Enable cluster scoped resources in projects

### DIFF
--- a/manifests/overlays/prod/projects/projects.yaml
+++ b/manifests/overlays/prod/projects/projects.yaml
@@ -8,6 +8,9 @@ spec:
     server: '*'
   sourceRepos:
   - '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -19,6 +22,9 @@ spec:
     server: '*'
   sourceRepos:
   - '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -30,6 +36,9 @@ spec:
     server: '*'
   sourceRepos:
   - '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -41,6 +50,9 @@ spec:
     server: '*'
   sourceRepos:
   - '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -52,6 +64,9 @@ spec:
     server: '*'
   sourceRepos:
   - '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -63,6 +78,9 @@ spec:
     server: '*'
   sourceRepos:
   - '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -85,3 +103,6 @@ spec:
     server: '*'
   sourceRepos:
   - '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'


### PR DESCRIPTION
Pulling downstream: https://github.com/operate-first/apps/pull/563

This PR resolves issues like:
![image](https://user-images.githubusercontent.com/7453394/116576027-7bb51280-a90f-11eb-88dd-5c133c2dd75b.png)
