### PR TITLE
Add dh-stage-trino in api.rhods-idh.dev.redhat.com cluster

### DIFF
--- a/manifests/overlays/prod/configs/argo_cm/resource.inclusions
+++ b/manifests/overlays/prod/configs/argo_cm/resource.inclusions
@@ -101,6 +101,8 @@
   clusters:
   - https://api.ocp.prod.psi.redhat.com:6443
   - https://api.ocp4.prod.psi.redhat.com:6443
+  - https://datahub.psi.redhat.com:443
+  - https://api.rhods-idh.dev.datahub.redhat.com:6443
 - apiGroups:
   - argoproj.io
   kinds:

--- a/manifests/overlays/prod/secrets/clusters/api.rhods-idh.dev.datahub.redhat.com.enc.yaml
+++ b/manifests/overlays/prod/secrets/clusters/api.rhods-idh.dev.datahub.redhat.com.enc.yaml
@@ -10,15 +10,16 @@ type: Opaque
 stringData:
     name: api.rhods-idh.dev.datahub.redhat.com
     config: ENC[AES256_GCM,data:iu/wBkISd9kuN9WweqDRBFysXIjaORO8QnkOrmldGHv+q00v1e+78DogThWy1NCXrA9ZaAQvaRFWLJy0AstH/Iu4DAgUrt2YlwOIKJuHrkUkJqYZHp4JtlO8JeJd2G4ToL0olmVVe4OqvdAmQVp9tnjX0l0W3zy6lsE4TUxBWJxBE7ZXwdMMD0gS2k9vriGlZlSsSMtj5spyQzTjT47rnW2NYRZFoERf985weTO1JGrfVrwyzkDWqimJ0DHhFosl5Snt09Ar1Wwt/Zd0by3Mo60FVQZk86Hy+PziXcvMNRD9LYBDR4fG6amyPY9nYsFy71VcUSyJkP5HWeYxXndREynsCgA+HlOtJJXw/1Qm1cRV0FD6LQIaiBuf6GdM1/SPSqdt87xfH8Ka7IMbUIXUpDqn6rMOIsyca7xFec5PeG0imwUZ2Xevk9aHybzYeKRjfCbcHzQrakKrZ3Q69R3nZ8S/x6SgGbWMQw/cV930JaeIvfMjlEg+4bJvc6YIyRLrGzbM5jbjaGP5SuBnnsRU2NJ2tlJriSyEuDW7wJv0MJ1yuE2cL74hejcbKvO3spLwpBpv26jzLhKT8FDFVDVdMagFBkVFajJYpRQdlQmJwKkbCUxTZmWUzLfGyU2NKEtl79KZbmd5IjMUnwOQTqksrfxhdJAH33xRjvLNNDgTRuI5LBiX5i87CY2PRvS0uQqjLqYnlnLnRiPS8eFJBDYKvz97R1I98iXfZfFCKjmx9YOJlKOZJNjt8j5wYBD4oybN1qM1k7jz/qN5XypBYqeawI9K82bXiAmwG7GIU/J5RHpMDQVL6r6xCnX8yfM8xHQ8IuJfYD4jA1A0n33zIrReKeM1cgJt/jxax1pmtllS/X8pwnDfmTusda9wY/uR583MH9fxAbgk/V0Ma2WZpqIRiwnIVR59asCfTXdj2XtUiIH4e0Y0AXSAKaJDCc6f90e8K1gcc3XzossQK8JxblePFPVe27BVeeBR5xiPFNBKuTjtPZHXc/nd1fCQ6ZRKuQeqUGc2vkk0mu6zeqDRuOFEwAUwFalLIT8mFcXyZ7P8GN1OMRccjIzYwmD76pJdPvRY2WPekLE3hd1J6WIn3ePjYcHoPzV0Ci0u75vFOznzz3iEN4Pz01FIte1FD1kbsTxma4VHscXqCqX2zAtCYAF268IuG7HTJgLFmCaftjFd1zq6EbqdNJEx7D+gTzOa3L3xP/CjESd5RuHV+Zp+HSKMPby1zguO1zelLIdYeaYvq49ASltwXPUSeQG+tXgJXYn4gz+ULTSdpspFPkMkmlnpwQirOYTxsmcTFOKA9zIwC64z3h/DE6zJ16go0k3o,iv:HAdia7FqGphOZIj4+SnlNrxbKzduLYqWJpRkhJKowGk=,tag:nBJA79NG4C7C4Qjv4+DFAw==,type:str]
-    namespaces: openshift-marketplace,redhat-ods-operator,redhat-ods-monitoring
+    namespaces: openshift-marketplace,redhat-ods-operator,redhat-ods-monitoring,dh-stage-trino
     server: https://api.rhods-idh.dev.datahub.redhat.com:6443
     shard: "0"
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2021-03-25T02:36:14Z'
-    mac: ENC[AES256_GCM,data:hmbsvzKvNKtLgVanyJX7kcOx9yzzPFh0c3eZqD7T0R/QQfzUHMNBHkdUohwBuTrmQwKrSDObbjO+unZWtBsuyXNbgkssIWVTtNIYoDqr+1zkH7bBxdVArtFHzwdlgmwfzUo68KjwNbFSsO3JfvRdmu3lGTZYszM2TmOah4oxQKQ=,iv:vE2IUB1gFkMFGh1gHjLA9JXN0+uxfEDyRamewSeg1+k=,tag:1z1ag3ftzRot+si6efHi2g==,type:str]
+    hc_vault: []
+    lastmodified: '2021-05-31T11:44:30Z'
+    mac: ENC[AES256_GCM,data:X+oQijwOe71DxuCiCeMD3txMpMsdzU4z+R5Xaz60tZEXAhvJrRnwgXuQ59qvFqFrHQ8qcANCJDeFsHtMCwvQOT3qyqGsiSPFEC/BiHwYjD5+wyrXzjgkdAX82lPODTBPQtTXXHdoiYXnTv3OurhKJAu2ccFo7c+8AxG4qVmQX38=,iv:92zpabuVOr0jK1LwKiw+HbwRTnmQbJP1Xt8fecIK9Rc=,tag:QiHUi1uinglDDieyjbXYlA==,type:str]
     pgp:
     -   created_at: '2021-03-19T20:17:04Z'
         enc: |


### PR DESCRIPTION
## This Pull Request implements
Add dh-stage-trino in api.rhods-idh.dev.redhat.com cluster, so ArgoCD can manage deployments

## If migrating an Application to ArgoCD
- [ ] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
