### PR TITLE
Fix ArgoCD configuration for OCP 3.11 clusters

### DIFF
--- a/manifests/overlays/prod/configs/argo_cm/resource.inclusions
+++ b/manifests/overlays/prod/configs/argo_cm/resource.inclusions
@@ -383,10 +383,6 @@
   - argoproj.io
   kinds:
   - CronWorkflow
-  - EventBus
-  - EventSource
-  - Gateway
-  - Sensor
   - Workflow
   - WorkflowTemplate
   clusters:


### PR DESCRIPTION
## This Pull Request implements
Fix ArgoCD configuration for OCP 3.11 clusters


## If migrating an Application to ArgoCD
- [ ] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
