### PR TITLE
Change git repository for dh-stage-trino

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-stage-trino.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-stage-trino.yaml
@@ -9,8 +9,8 @@ spec:
   project: data-hub
   source:
     path: trino/overlays/stage
-    repoURL: https://github.com/AICoE/idh-manifests.git
-    targetRevision: production
+    repoURL: https://github.com/AICoE/internal-data-hub.git
+    targetRevision: main
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## This Pull Request implements

`dh-stage-trino` project will now use a new GitHub repository to deploy Trino, which will use the upstream ODH operator and then apply the changes required to have Trino running on stage

Explain your changes.

This is the first movement to get all Internal Data Hub systems using upstream ODH instead of the forked repo.

## If migrating an Application to ArgoCD
- [X] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
