### PR TITLE
Adjust path to manifests and add graph-metrics-exporter to test

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-metrics-exporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-metrics-exporter.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth-stage
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
-    path: metrics-exporter/overlays/ocp4-stage
+    path: graph-metrics-exporter/overlays/ocp4-stage
     targetRevision: master
   destination:
     server: 'https://api.ocp4.prod.psi.redhat.com:6443'
@@ -16,3 +16,9 @@ spec:
     automated:
       selfHeal: true
       prune: true
+  ignoreDifferences:
+    - group: batch
+      kind: CronJob
+      name: graph-metrics-exporter
+      jsonPointers:
+        - /spec/jobTemplate/spec/template/spec/containers/0/image

--- a/manifests/overlays/prod/applications/thoth-station/test/kustomization.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - test-thoth-chat-notification.yaml
 - test-thoth-cve-update.yaml
 - test-thoth-graph-backup.yaml
+- test-thoth-graph-metrics-exporter.yaml
 - test-thoth-graph-schema-update.yaml
 - test-thoth-graph-refresh.yaml
 - test-thoth-graph-sync.yaml

--- a/manifests/overlays/prod/applications/thoth-station/test/test-thoth-graph-metrics-exporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/test/test-thoth-graph-metrics-exporter.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ocp4-test-thoth-graph-metrics-exporter
+spec:
+  project: thoth-dev
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: graph-metrics-exporter/overlays/test
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
+    namespace: thoth-test-core
+  syncPolicy:
+    automated: {}


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## This Pull Request implements

Adjust path that is in conflict with another application
Add graph-metrics-exporter to test for Thoth station


## If migrating an Application to ArgoCD
- [ ] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
