### PR TITLE
Change Stage superset deployment to use internal-data-hub repo

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-stage-superset.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-stage-superset.yaml
@@ -8,14 +8,9 @@ spec:
     server: 'https://paas.stage.psi.redhat.com:443'
   project: data-hub
   source:
-    path: superset
-    repoURL: https://github.com/AICoE/idh-manifests.git
-    targetRevision: production
-    plugin:
-      name: helmSecrets
-      env:
-        - name: VALUES_FILES
-          value: "-f secrets.enc.yaml -f helm_vars/stage/secrets.yaml -f helm_vars/stage/values.yaml"
+    path: kfdefs/overlays/prod/dh-stage-trino
+    repoURL: https://github.com/AICoE/internal-data-hub.git
+    targetRevision: main
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## This Pull Request implements
Change superset deployment to use internal-data-hub repo


## If migrating an Application to ArgoCD
- [X] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
