### PR TITLE
Fix dh-stage-superset paths

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-stage-superset.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-stage-superset.yaml
@@ -8,7 +8,7 @@ spec:
     server: 'https://paas.stage.psi.redhat.com:443'
   project: data-hub
   source:
-    path: kfdefs/overlays/prod/dh-stage-trino
+    path: kfdefs/overlays/stage/dh-stage-trino
     repoURL: https://github.com/AICoE/internal-data-hub.git
     targetRevision: main
   syncPolicy:


### PR DESCRIPTION
## This Pull Request implements
Fix the paths for dh-stage-superset


## If migrating an Application to ArgoCD
- [X] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
