### PR TITLE
Remove auto-sync option from dh-prod-data-catalog-usir namespace

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-prod-data-catalog-usir.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-data-catalog-usir.yaml
@@ -12,9 +12,6 @@ spec:
     repoURL: https://github.com/AICoE/idh-manifests.git
     targetRevision: production
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
     - Validate=false
   ignoreDifferences:


### PR DESCRIPTION
## This Pull Request implements
Remove auto-sync option from dh-prod-data-catalog-usir namespace


## If migrating an Application to ArgoCD
- [X] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
