### PR TITLE
Add dh-prod-thanos-extractor and dh-prod-argo applications for DH-OCP4

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-prod-argo.ocp4.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-argo.ocp4.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -11,6 +12,27 @@ spec:
     path: components/project-admin-rolebindings/data-hub
     repoURL: https://github.com/AICoE/internal-data-hub.git
     targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo.ocp4.dh-prod-argo
+spec:
+  destination:
+    namespace: dh-prod-argo
+    server: https://api.datahub-ocp4.prod.psi.redhat.com:6443
+  project: data-hub
+  source:
+    path: argo/overlays/dh-prod-argo
+    repoURL: https://github.com/AICoE/idh-manifests.git
+    targetRevision: production
   syncPolicy:
     automated:
       prune: true

--- a/manifests/overlays/prod/applications/data_hub/dh-prod-thanos-extractor.ocp4.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-thanos-extractor.ocp4.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -11,6 +12,27 @@ spec:
     path: components/project-admin-rolebindings/data-hub
     repoURL: https://github.com/AICoE/internal-data-hub.git
     targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo.ocp4.dh-prod-thanos-extractor
+spec:
+  destination:
+    namespace: dh-prod-thanos-extractor
+    server: https://api.datahub-ocp4.prod.psi.redhat.com:6443
+  project: data-hub
+  source:
+    path: argo/overlays/dh-prod-thanos-extractor
+    repoURL: https://github.com/AICoE/idh-manifests.git
+    targetRevision: production
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
- IDH-152

## This Pull Request implements

Adds Internal Data Hub argo applications to begin migration process to new OCP4 cluster


## If migrating an Application to ArgoCD
- [ ] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
