### PR TITLE
correct the overlays path for thoth services

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-backend.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-backend.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth-stage
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
-    path: graph-sync/overlays/ocp4-stage
+    path: graph-sync/overlays/ocp4-stage/backend
     targetRevision: master
   destination:
     server: 'https://api.ocp4.prod.psi.redhat.com:6443'

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-middletier.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-middletier.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth-stage
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
-    path: graph-sync/overlays/ocp4-stage
+    path: graph-sync/overlays/ocp4-stage/middletier
     targetRevision: master
   destination:
     server: 'https://api.ocp4.prod.psi.redhat.com:6443'

--- a/manifests/overlays/prod/applications/thoth-station/prod/prod-slo-reporter.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/prod/prod-slo-reporter.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth-stage
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
-    path: slo-reporter/overlays/zero-prod-ocp4-stage
+    path: slo-reporter/overlays/moc-prod-ocp4-stage
     targetRevision: master
   destination:
     server: 'https://api.ocp4.prod.psi.redhat.com:6443'

--- a/manifests/overlays/prod/applications/thoth-station/prod/prod-thoth-integration-tests.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/prod/prod-thoth-integration-tests.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth-stage
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
-    path: integration-tests/overlays/cnv-prod-ocp4-stage
+    path: integration-tests/overlays/moc-prod-ocp4-stage
     targetRevision: master
   destination:
     server: 'https://api.ocp4.prod.psi.redhat.com:6443'


### PR DESCRIPTION
correct the overlays path for thoth services
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## This Pull Request implements

We have to change the overlay location. 
so this fixes them
Related-To: https://github.com/thoth-station/thoth-application/pull/2015
