### PR TITLE
Update/Add overlays for Argos and Obslytics for OCP4 Migration

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-prod-argo.ocp4.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-argo.ocp4.yaml
@@ -30,7 +30,7 @@ spec:
     server: https://api.datahub-ocp4.prod.psi.redhat.com:6443
   project: data-hub
   source:
-    path: argo/overlays/dh-prod-argo
+    path: argo/overlays/ocp4.dh-prod-argo
     repoURL: https://github.com/AICoE/idh-manifests.git
     targetRevision: production
   syncPolicy:

--- a/manifests/overlays/prod/applications/data_hub/dh-prod-obslytics.ocp4.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-obslytics.ocp4.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dh-prod-obslytics
+spec:
+  destination:
+    namespace: dh-prod-thanos-extractor
+    server: https://api.datahub-ocp4.prod.psi.redhat.com:6443
+  project: data-hub
+  source:
+    path: obslytics/overlays/ocp4-migration
+    repoURL: https://github.com/AICoE/internal-data-hub.git
+    targetRevision: main

--- a/manifests/overlays/prod/applications/data_hub/dh-prod-thanos-extractor.ocp4.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-thanos-extractor.ocp4.yaml
@@ -30,7 +30,7 @@ spec:
     server: https://api.datahub-ocp4.prod.psi.redhat.com:6443
   project: data-hub
   source:
-    path: argo/overlays/dh-prod-thanos-extractor
+    path: argo/overlays/ocp4.dh-prod-thanos-extractor
     repoURL: https://github.com/AICoE/idh-manifests.git
     targetRevision: production
   syncPolicy:


### PR DESCRIPTION
- IDH-152
- IDH-161

## This Pull Request implements
- Point dh-prod-argo and dh-prod-thanos-extractor ocp4 applications to point to their own overlay in idh-manifests
- Create app for ocp4 migration of Obslytics pipelines Application
