### PR TITLE
Add Argoproj resources to include list for datahub-ocp4

### DIFF
--- a/manifests/overlays/prod/configs/argo_cm/resource.inclusions
+++ b/manifests/overlays/prod/configs/argo_cm/resource.inclusions
@@ -417,6 +417,7 @@
   - WorkflowTemplate
   clusters:
   - https://datahub.psi.redhat.com:443
+  - https://api.datahub-ocp4.prod.psi.redhat.com:6443
   - https://paas.stage.psi.redhat.com:443
   - https://api.rhods-idh.dev.datahub.redhat.com:6443
 - apiGroups:


### PR DESCRIPTION
Adds datahub-ocp4 to list of clusters that can include argoproj.io Resources