### PR TITLE
ignore the metadata label from thoth graph sync apps

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-backend.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-backend.yaml
@@ -22,3 +22,8 @@ spec:
       name: graph-sync-job
       jsonPointers:
         - /metadata/labels
+    - group: template.openshift.io
+      kind: Template
+      name: graph-sync
+      jsonPointers:
+        - /metadata/labels

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-middletier.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-graph-sync-middletier.yaml
@@ -22,3 +22,8 @@ spec:
       name: graph-sync-job
       jsonPointers:
         - /metadata/labels
+    - group: template.openshift.io
+      kind: Template
+      name: graph-sync
+      jsonPointers:
+        - /metadata/labels


### PR DESCRIPTION
ignore the metadata label from thoth graph sync apps
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## This Pull Request implements

This would ignore the labels which are not needed for sync of the thoth graph app.
Related-to: https://github.com/thoth-station/thoth-application/issues/2054
