### PR TITLE
Break out monitoring inclusions for data hub clusters

### DIFF
--- a/manifests/overlays/prod/configs/argo_cm/resource.inclusions
+++ b/manifests/overlays/prod/configs/argo_cm/resource.inclusions
@@ -232,6 +232,13 @@
   - ServiceMonitor
   clusters:
   - https://api.ocp4.prod.psi.redhat.com:6443
+- apiGroups:
+  - monitoring.coreos.com
+  kinds:
+  - PodMonitor
+  - PrometheusRule
+  - ServiceMonitor
+  clusters:
   - https://api.rhods-idh.dev.datahub.redhat.com:6443
   - https://api.datahub-ocp4.prod.psi.redhat.com:6443
 - apiGroups:


### PR DESCRIPTION
Our permissions on the datahub-ocp4 cluster don't match those on the
ocpr.prod.psi cluster, so we can't create Prometheus and Alertmanager
instances. This change makes our per-cluster inclusions reflect that
reality.

## This Pull Request implements

Explain your changes.


## If migrating an Application to ArgoCD
- [ ] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
