### PR TITLE
Remove broken stage applications from kustomization

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/kustomization.yaml
+++ b/manifests/overlays/prod/applications/data_hub/kustomization.yaml
@@ -4,16 +4,12 @@ resources:
 - dh-prod-jupyterhub.yaml
 - dh-psi-monitoring.yaml
 - dh-prod-kafka.yaml
-- dh-stage-jupyterhub.yaml
 - dh-stage-kafka.yaml
-- dh-stage-rsyslog.yaml
 - dh-prod-rsyslog.yaml
-- dh-stage-analytics-factory.yaml
 - dh-prod-analytics-factory.yaml
 - dh-prod-data-catalog-ccx.yaml
 - dh-stage-superset.yaml
 - dh-prod-superset.yaml
-- dh-stage-argo.yaml
 - dh-prod-argo.yaml
 - dh-stage-trino.yaml
 


### PR DESCRIPTION
The old paas.stage cluster has been decommissioned. We have a few ArgoCD
apps that are attempting to deploy to that cluster and therefore stuck
in an unknown state.

We don't necessarily want to delete these application definitions
entirely yet, but we don't care enough about these apps to get them
working on another cluster. Deleting them from the kustomization file
and then removing the apps from ArgoCD, while keeping the app
definitions here in git for potential future use, seemed like a
reasonable course of action to stop the alerts we're getting about out
of sync argocd apps.

## This Pull Request implements

Explain your changes.


## If migrating an Application to ArgoCD
- [ ] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
