### PR TITLE
Add dh-prod-superset manifest to psi ocp4

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-prod-superset.ocp4.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-superset.ocp4.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ocp4.dh-prod-superset
+spec:
+  destination:
+    namespace: dh-prod-superset
+    server: https://api.datahub-ocp4.prod.psi.redhat.com:6443
+  project: data-hub
+  source:
+    path: kfdefs/overlays/prod/dh-prod-superset
+    repoURL: https://github.com/AICoE/internal-data-hub.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/manifests/overlays/prod/applications/data_hub/kustomization.yaml
+++ b/manifests/overlays/prod/applications/data_hub/kustomization.yaml
@@ -30,3 +30,4 @@ resources:
 - dh-prod-docs.yaml
 - dh-stage-docs.yaml
 - dh-prod-monitoring.yaml
+- dh-prod-superset.ocp4.yaml

--- a/manifests/overlays/prod/secrets/clusters/api.datahub-ocp4.prod.psi.redhat.com.enc.yaml
+++ b/manifests/overlays/prod/secrets/clusters/api.datahub-ocp4.prod.psi.redhat.com.enc.yaml
@@ -10,15 +10,16 @@ type: Opaque
 stringData:
     name: datahub-ocp4.psi.redhat.com
     config: ENC[AES256_GCM,data:e+OKpwJnm2Th/Z7GI+BCUKf2WqBlRfuBjbxObwerEwdO7sobGBgmsIUA4XIY0oSkOIjoDDu6W+Cj171GCjMpJ3aKX12LpYaw2bjtZxec97jE0lMdHGr/ExwLL/R+aM/uOMMjMpDSROT68VnH1ROcCwrZFiAVFPLnlOmkCYaPtVvW5ONw3lezsS3USNl47jxuCLsO/PfeysUuL8GeSboG5+u2ovDCphnyOyWaAqh4GACxO7mtceKSpSqo/7AMFNLNdyFPueGPvOeMew53pIQ3+lX0igwVskeqDhrV0trrnnie/kG6P6h66neZV2ZAuCcD7W/9SVBPJCS8wGe88J9+iGTZwZbl8SoNEKb/IJcZS+54T0At0FErMGWKFwpY6mVpS+OdPKqtgUF8WdTzHn1G1994963hAXMCtPMAaklv2bq65SCDXrHCaGWQ3dOvcmBOvRY9QlRM8SbOKxmZoE/YthIwseqthi5ZavwNZurQnEq6xRfmMkZzmffXjzMxbMt4yOnpROTG/oxcp7JXdM9QScNS20LOI30sypptzCZUtbL9KG4mcUKJaAH3bKm66saEDAkguTmZ2vRb8n2taQa0p2OJmOBDHyvmdA3IQ2bZ07ZQDyjJtRuYyT0BX+qfaQqDatebLhC4feQ+z/dSnu41UXq9rOZriK/L/wRoBssNKjDD0xQobwFBf564YWy8mPIyMezfxadDVEcvwIUMWkma3jRUZTZAreve+Gv47S5ZKSji4wiSeiAs8RnNf1+cgqdxAvVvB8IO7T/h3BOZfJ5SiTEc/Yqte9siyf21awIDDvnXMmBgsBeF+RyllB1bldOxVLrQqbqQg/1P4WsDNFllCUhUj6CkbCmepdN6SSAcBqRU4rCOk+TC7lIwCA27VCiz69m0ynrM/C3JNcQIjZIAL5wXkwzqvzpnV87BTQ1qbazHkFgxeNDxUEl7SNRRmq3Mp4G3hpfQMc9uaFdV9AlYpB1RA/Pl01nVLOsmQbBUVFNe5YUNQo5xdYE/Pk08ZxlMU6sdLvFEnjpb7X5d07TsIJMfJgoR6U7qi4cehk4jMHLeyXana9D++1snhza3uE/5AHZGoAs+O59/JjmR3Nikn64LTGYJCfYb/4KN6wQKiBwEm9ckSIR49Jq6xF2Lp3jBxHbnzsccQ+FjD56eBHw/0tPwJZvI/dJ77n4h9eBvLhd78DRfn8iDIT8Yz7VSId1142i2rNIpYidB4pWplp12ONVQl93d6hFRZTrLCrd7et0sAZEW13Ms+CsWEO5NECyUVJDBzs2dFg7dd8R/r46grpO7Y5O65kIqOaV2bieTPSKnaFtFCRTeYZlpkRgVWBPf1KfFDlw6AZANs3oviSWK1OLEvtMIIWFnXo23I8VSqpBqv3YFUMFA3mIE/uSpybZVUnwQmklj4fPqaxldyxgfREAMmPZrZWIXI8S3IzeWd1HFIEH7xflY0hB0/CQ4iZyPxMRQK+T9Axe5y8DNRVjrRqY01KEtXHTN+Ijy56xO12Sc3cJg2lDqoW7mU+IAKmcBE732W7HZ0TvEPIhbJGBtypK+nbik9FGbMmrjNttJZm+g12MRRcJCZB8ylFnLizcxU8qRYlMn8uv0wrUeXafmbyuBPNB9P4ESQYF41/a1N4TOP/mN5eJ5c0KVHQEwECuXEQ/T7mfleN1yAUonmusBCPskPhPkqmybkp72K8tVLlaPypRDAipQhc83h932vw7Yz+U/Md9fHCR6yWrgztPduY5N3UwSmmG4rmr46pdTb41Hl7VZhRndVD415LX5XLfleNI=,iv:UCDrFiIiGjM/BrD475QJq4pgXdOAGGQKeB2zISdnLcQ=,tag:WzgiGaVX7H9+MIZMn4pRNg==,type:str]
-    namespaces: argocd-manager,dh-prod-argo,dh-prod-thanos-extractor,redhat-ods-applications,redhat-ods-monitoring,redhat-ods-operator,dh-sandbox-telemetry-grafana,dh-prod-telemetry-grafana,dh-prod-trino,dh-prod-docs,dh-prod-monitoring
+    namespaces: argocd-manager,dh-prod-argo,dh-prod-thanos-extractor,redhat-ods-applications,redhat-ods-monitoring,redhat-ods-operator,dh-sandbox-telemetry-grafana,dh-prod-telemetry-grafana,dh-prod-trino,dh-prod-docs,dh-prod-monitoring,dh-prod-superset
     server: https://api.datahub-ocp4.prod.psi.redhat.com:6443
     shard: "0"
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2021-11-11T19:25:48Z'
-    mac: ENC[AES256_GCM,data:6XKQIX3OBLi0qvjV9422TQCxZyEP8e2msWqKOXzOB4oshDPx2E3u5bJf0MyK/kF7QFEdJ3S4fFzH6/cNIr8sk5QvRtYlqbyjHGGMUAt4v+muaTGSJa9CTIRmEzdAxhWCyWJwEEi7SveA4TkCNFCmGYxAhrHmdK2O3SmA+QT3e2M=,iv:5O4x5mpxXGQrSApOdvpZxy7b0S+kVAMOb4qvDF7So1Y=,tag:9c9pY3+MK7iVZtlfBjiCew==,type:str]
+    hc_vault: []
+    lastmodified: '2021-11-30T17:29:07Z'
+    mac: ENC[AES256_GCM,data:SAs3vZ4iFYw1jJBIvovxpG0k+j6vhIPJSA7V3s47aYnxj2vSeLy7eSRVF9c3eW38bXKpuS7Ozniqn/jer78pjJ/Gx7Fjtu4L0KBUTguL5e4J+aTkW8vf6NzT+WsZPrQ7vneCykFcsbujsteKrRvEt2w5iO+aDRXX+rp024bjhio=,iv:c7Ac8lEst0wavB7n9c86WYOcHkf/F3yny5bus3KEt6E=,tag:Mqc7Rkbos5+zaZUisZ0yUw==,type:str]
     pgp:
     -   created_at: '2021-10-12T19:28:08Z'
         enc: |


### PR DESCRIPTION
## This Pull Request implements
Migrate dh-prod-superset to the new psi ocp4


## If migrating an Application to ArgoCD
- [X] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
