### PR TITLE
Add Grafana to OCP4 Data Hub

### DIFF
--- a/manifests/overlays/prod/applications/data_hub/dh-prod-monitoring-grafana.yaml
+++ b/manifests/overlays/prod/applications/data_hub/dh-prod-monitoring-grafana.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dh-prod-monitoring-grafana
+spec:
+  destination:
+    namespace: dh-prod-monitoring
+    server: https://api.datahub-ocp4.prod.psi.redhat.com:6443
+  project: data-hub-dev
+  source:
+    path: grafana/overlays/prod
+    repoURL: https://github.com/AICoE/internal-data-hub.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/manifests/overlays/prod/applications/data_hub/kustomization.yaml
+++ b/manifests/overlays/prod/applications/data_hub/kustomization.yaml
@@ -29,4 +29,5 @@ resources:
 - dh-prod-docs.yaml
 - dh-stage-docs.yaml
 - dh-prod-monitoring.yaml
+- dh-prod-monitoring-grafana.yaml
 - dh-prod-superset.ocp4.yaml


### PR DESCRIPTION
I've added it to the data hub dev project for now so we don't get
alerted for failing syncs

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>
