### PR TITLE
updating pre-commit protocol to https

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 exclude: /configs
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.1
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:
       - id: trailing-whitespace


### PR DESCRIPTION
## This Pull Request implements

Explain your changes.

Unecrypted git protocol has been deprecated from use in github. Switching to https.
Related to: https://github.com/thoth-station/thoth-application/issues/2111