### PR TITLE
Remove dh-prod-ingest namespace as it no longer exists on the old prod cluster

### DIFF
--- a/manifests/overlays/prod/secrets/clusters/datahub.psi.redhat.com.enc.yaml
+++ b/manifests/overlays/prod/secrets/clusters/datahub.psi.redhat.com.enc.yaml
@@ -10,16 +10,15 @@ type: Opaque
 stringData:
     name: datahub.psi.redhat.com
     config: ENC[AES256_GCM,data:CGSsQ8vTGpMALg2+E3mUwc1HpR3Vek+idXQDQN6COeGgYA3X1PNMZNhRPFZvU9Uqn9MAJUQaRo3DiDFkQ9SI7ySaQS48JOueIEinSP9qd2dLZPO0U+QkyrBGPkPC41/W63JieAWtTMPViA/B8zjfNhv1PMyrK0ySu0TiEWfo+99CeQSVkkv6e7WAEufjCN1El4MoP1j/+TgrTPLgUImT/TXp/chPFUwZLqWKvlQnmIW+3ZG/S7gkO+H4ur9w4wn4k1OfRtfApD4BHX/XFS/OLjaI6fhH6D/U9M7+1IZyfVo4SAL9rKUzYiIQ+FiKQfc6ADC5Hb4HX9cXHPCUsZLIcN3Dm+FBGUiTDF2Cit6CXiINDoscoNgsBWR3RCfXf25dxfKalXhagZ/ALh54xYPkFHbwB92Xw07mwXIDhSACbsQLQwu9f/RxuxSRW1CymnS2m0CaySes1ZTkSGkDNNd28pY8vxNu9OaTt6wP6SgqWXMpqus+LAjRgPzEVu+URiN1FRMI85twBRfX9xLpIWkopjEf/9KdTWC5DbnRLw5f6e6W7IgmpwC+QwDF3IulD09JfkY4p0bf1Own+CUdqP/U/dQrm4q4LvHkswcqvZWJvM1fYEB4tTIFSvmV6NuzRfMRIs/ykht3NJKLmiTH8kNzPuIc3wpj0kkGxdC+6qmyCn44n0Iu/etEbJ+aRE5JEID1DnBqJznoufmSC+AwzyRKq6CTaotbhIBSFz0lhYWSRRY/na9ns31xL9wIuf/v37HoLlqy6SQH3uRisRJR61wdAg4dI9cP+vZJS/kwVUU/c3IPBcwxzhjoRNVu52R22cmUtQoNJgFDTW5Lg/zVtTngQIzLqc0iooXowXHFQv1UcCcld+M0PMGQdlsVb4qVAcUN8z3Q7tYJNaI2xGP+5oFFZa8w2fmamREzbQwXGBBmE2FaW8cZilbjlqU2XDHI35sI2gn5uYhO7aDhgl1YDEM0yd+1FQwKREodpzQDOglViF97VlxftKLNfWq2ghdWe0sZWmbpt46CB/0vzZOSceaSnAV/CLYV4Y1EeprRAgJT6DeqCRbHGTQjFZd7ym3w5MfWvdUJKJ+O+y/aCYWKEI46eChn34chXI4W9IY5yB5lcJoTtD71apC36Nc0caepo1UPzlCJ6vr4A/0YtdDIT3ixwiD7iqpK6XQc5oKtsgX7qbCoYSNxaNWP+5ZPrYW6R1FRNuyQwEEwH0/AKD8d30aaDQpy1dYQRLMTsKTTczxvjw2AUso=,iv:u0wWP5y+GlAO2MsCaeZtiS7/kKGsRiy1lF0BBJJGsNU=,tag:+EnXUNYwF59eLmgXIjd9Tw==,type:str]
-    namespaces: dh-prod-jupyterhub,dh-prod-message-bus,dh-prod-ingest,dh-prod-data-catalog-ccx
+    namespaces: dh-prod-jupyterhub,dh-prod-message-bus,dh-prod-data-catalog-ccx
     server: https://datahub.psi.redhat.com:443
     shard: "0"
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    hc_vault: []
-    lastmodified: '2022-07-01T14:08:37Z'
-    mac: ENC[AES256_GCM,data:wS605kkdO3sbZLUy7nmw2w0sigtu/NH7m8TeZZ/dmW0M+f3JZZjpqMuzsrBw3Af4wkxyoGHesdB0yE+B21BPrCo7LYwqa5iTrTD6FoQTs7eIF3AfUACcjrGsw4x0qOeIyDBH+4P6GAgi2HrDKObXzIxvfSjxVVix/BsXTfpIr58=,iv:TojBvXvlT0OLVpf4K0yI02bS8FbOFTk3zFE/UeyLpms=,tag:oTnLraNmQGtHLFp6hmLIpA==,type:str]
+    lastmodified: '2022-07-05T13:19:25Z'
+    mac: ENC[AES256_GCM,data:f15Rmqirz8/ZH0w/RxpmTL4Sf+u6EwAtUsEL1NJ4GdLvvG9agHNmmbZ81melt+CSRpGDT2IvZLJHN3S3UfKG1Rxpiue95WcyhFzAcpPvA3S4STOmP3rBDbXHt+u8cGaxY1tQdsjWK6cedYdeXv0iCQGRjR9HXoyyQi+s06BdDM0=,iv:ZtH4JySTKf2aNgqG9+KpMTwuxEpjsO2WEC5FtyGqrvc=,tag:BROfJlPw6EgpYiRUzHH0aA==,type:str]
     pgp:
     -   created_at: '2020-08-10T01:26:30Z'
         enc: |


### PR DESCRIPTION
Signed-off-by: Anish Asthana <anishasthana1@gmail.com>

## This Pull Request implements

Explain your changes.


## If migrating an Application to ArgoCD
- [ ] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
