### PR TITLE
Remove 4n4nd as reviewer and approver from the repo OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - 4n4nd
   - accorvin
   - anishasthana
   - gmfrasca
@@ -13,7 +12,6 @@ approvers:
   - lucferbux
 
 reviewers:
-  - 4n4nd
   - accorvin
   - anishasthana
   - gmfrasca


### PR DESCRIPTION


## This Pull Request implements

Explain your changes.

Remove 4n4nd as reviewer and approver from the repo OWNERS

## If migrating an Application to ArgoCD
- [ ] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
