### PR TITLE
:chart_with_downwards_trend: Include thoth monitoring app into ocp argocd

### DIFF
--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/kustomization.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
 - stage-thoth-kebechet.yaml
 - stage-thoth-management-api.yaml
 - stage-thoth-metrics-exporter.yaml
+- stage-thoth-monitoring.yaml
 - stage-thoth-package-extract.yaml
 - stage-thoth-package-releases.yaml
 - stage-thoth-package-update.yaml

--- a/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-monitoring.yaml
+++ b/manifests/overlays/prod/applications/thoth-station/ocp4-stage/stage-thoth-monitoring.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stage-thoth-monitoring
+spec:
+  project: thoth-stage
+  source:
+    repoURL: 'https://github.com/thoth-station/thoth-application.git'
+    path: monitoring/overlays/ocp4-stage
+    targetRevision: master
+  destination:
+    server: 'https://api.ocp4.prod.psi.redhat.com:6443'
+    namespace: aicoe-infra-prod
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+    - Validate=false


### PR DESCRIPTION
Include thoth monitoring app into ocp argocd
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## This Pull Request implements

Related-to: https://github.com/thoth-station/thoth-application/issues/2455
- Include project thoth monitoring deploying on PSI ocp4 to be handled via argocd

## If migrating an Application to ArgoCD
- [x] I have completed the list of action items on [this page](https://aicoe.github.io/aicoe-cd/get_argocd_to_manage_your_app/)
